### PR TITLE
refactor(levels): declarative levels.yaml + per-level expert toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ node_modules/
 # throwaway smoke-test venv (not the poetry env)
 .venv-smoke/
 .venv-test/
+trace/

--- a/server/config.py
+++ b/server/config.py
@@ -32,20 +32,10 @@ MED_MODEL = os.getenv("MED_MODEL", "medgemma-1.5-4b-it")
 SYNTHESIZER_MODEL = os.getenv("SYNTHESIZER_MODEL", ORCHESTRATOR_MODEL)
 CLINICAL_RESEARCH_MODEL = os.getenv("CLINICAL_RESEARCH_MODEL", "gemma-3-1b-it")
 
-# The three published team LEVELS (low / med / high). Each level fixes the synthesizer
-# + clinical-expert MODEL; the orchestrator (ORCHESTRATOR_MODEL) is shared across levels.
-# Persistent + env-overridable so the exact LM Studio ids are set without code edits.
-# The `low` level additionally runs an optimized synthesis prompt (team.py TEAM_PRESETS).
-SYNTH_MODEL_HIGH = os.getenv("SYNTH_MODEL_HIGH", "qwen3.6-35b-a3b-mlx")        # ~20GB MoE, reasoning (thinking always on in LM Studio)
-SYNTH_MODEL_MED = os.getenv("SYNTH_MODEL_MED", "qwen2.5-32b-instruct")         # ~18GB dense, non-reasoning (clean JSON, no thinking trace)
-SYNTH_MODEL_LOW = os.getenv("SYNTH_MODEL_LOW", "qwen2.5-14b-instruct-mlx")     # ~8GB dense, non-reasoning
-EXPERT_MODEL_HIGH = os.getenv("EXPERT_MODEL_HIGH", "medgemma-27b-text-it-mlx")  # 16GB; high-only
-EXPERT_MODEL_MED = os.getenv("EXPERT_MODEL_MED", MED_MODEL)   # medgemma-1.5-4b-it — shared with low so low+med simu-load fits 64GB
-EXPERT_MODEL_LOW = os.getenv("EXPERT_MODEL_LOW", MED_MODEL)   # medgemma-1.5-4b-it
-# HIGH uses a stronger orchestrator (gemma-4-26b-a4b) than the shared e4b: the orchestrator emits only
-# short tool-loop decisions (below the gemma-4 long-JSON collapse threshold), so the bigger MoE removes
-# the e4b reasoning bottleneck without collapse risk. low/med keep the e4b orchestrator (ORCHESTRATOR_MODEL).
-ORCHESTRATOR_MODEL_HIGH = os.getenv("ORCHESTRATOR_MODEL_HIGH", "google/gemma-4-26b-a4b")
+# Per-tier models (orchestrator / expert / synthesizer per level) now live in
+# server/levels.yaml, resolved by levels_loader and passed to run_team per request.
+# ORCHESTRATOR_MODEL / MED_MODEL / SYNTHESIZER_MODEL above are only the fallback
+# defaults for direct run_team calls (tests) and the raw-passthrough path.
 
 # Legacy alias for backward compatibility
 GENERAL_MODEL = ORCHESTRATOR_MODEL

--- a/server/levels.yaml
+++ b/server/levels.yaml
@@ -16,13 +16,11 @@ levels:
     orchestrator: gemma-e2b-q2     # gemma-4-E2B 2-bit (deliberately tiny orchestrator)
     expert: medgemma-1.5-4b        # small expert (~3GB); set to null to drop the expert
     synthesizer: qwen3-4b
-    synthesis_prompt: synthesis-low
 
   med-agent-team-low-validated:    # LOW + a validator at a competent FLOOR (not tier-scaled)
     orchestrator: gemma-e2b-q2
     expert: medgemma-1.5-4b
     synthesizer: qwen3-4b
-    synthesis_prompt: synthesis-low
     validator: gemma-e4b-q8        # floor candidate — try e4b first (2-bit e2b over-flagged); compare vs 12b
     validator_max_loops: 1
 
@@ -30,7 +28,6 @@ levels:
     orchestrator: gemma-e2b-q2
     expert: medgemma-1.5-4b
     synthesizer: qwen3-4b
-    synthesis_prompt: synthesis-low
     validator: gemma-4-12b
     validator_max_loops: 1
 

--- a/server/levels.yaml
+++ b/server/levels.yaml
@@ -27,3 +27,8 @@ levels:
     orchestrator: gemma-31b        # gemma-4-31B-it
     expert: medgemma-27b
     synthesizer: qwen3.6-35b-q6    # Qwen3.6-35B-A3B 6-bit (thinking synth)
+
+  med-agent-team-12b:
+    orchestrator: gemma-4-12b      # gemma-4-12B-it Q8 — strong dense orchestrator
+    expert: medgemma-1.5-4b-q8     # same expert as MED — isolates the orchestrator variable
+    synthesizer: qwen2.5-14b       # same synth as MED

--- a/server/levels.yaml
+++ b/server/levels.yaml
@@ -1,0 +1,29 @@
+# Advertised team levels — the /v1/models groupings the consumer's picker lists.
+#
+# Each key is a level id; each value fixes the per-role models (served by
+# LLM_BASE_URL) plus optional per-level prompt files. Read PER REQUEST, so editing
+# this (bind-mounted) file changes behaviour with no rebuild. This file is the
+# single source of truth for the team tiers.
+#
+#   add / remove a level     -> add / remove a block
+#   change a model           -> edit one line
+#   per-level prompt         -> set orchestrator_prompt / expert_prompt / synthesis_prompt
+#   run a level with NO expert -> `expert: null` (drops the medical_expert tool + role)
+#
+# Model ids are the LLM backend's served ids (the llama-router section names).
+levels:
+  med-agent-team-low:
+    orchestrator: gemma-e2b
+    expert: medgemma-1.5-4b        # small expert; set to null to drop the expert
+    synthesizer: qwen3-4b
+    synthesis_prompt: synthesis-low
+
+  med-agent-team-med:
+    orchestrator: gemma-e4b
+    expert: medgemma-1.5-4b
+    synthesizer: qwen2.5-14b
+
+  med-agent-team-high:
+    orchestrator: gemma-31b
+    expert: medgemma-27b
+    synthesizer: qwen3.6-35b

--- a/server/levels.yaml
+++ b/server/levels.yaml
@@ -18,12 +18,12 @@ levels:
     synthesizer: qwen3-4b
     synthesis_prompt: synthesis-low
 
-  med-agent-team-low-validated:    # LOW + orchestrator-as-validator (scaled to the tier)
+  med-agent-team-low-validated:    # LOW + a validator at a competent FLOOR (not tier-scaled)
     orchestrator: gemma-e2b-q2
     expert: medgemma-1.5-4b
     synthesizer: qwen3-4b
     synthesis_prompt: synthesis-low
-    validator: gemma-e2b-q2        # the LOW orchestrator, cross-family vs qwen3-4b synth (tests the floor)
+    validator: gemma-e4b-q8        # floor candidate — try e4b first (2-bit e2b over-flagged); compare vs 12b
     validator_max_loops: 1
 
   med-agent-team-med:

--- a/server/levels.yaml
+++ b/server/levels.yaml
@@ -13,17 +13,17 @@
 # Model ids are the LLM backend's served ids (the llama-router section names).
 levels:
   med-agent-team-low:
-    orchestrator: gemma-e2b
-    expert: medgemma-1.5-4b        # small expert; set to null to drop the expert
+    orchestrator: gemma-e2b-q2     # gemma-4-E2B 2-bit (deliberately tiny orchestrator)
+    expert: medgemma-1.5-4b        # small expert (~3GB); set to null to drop the expert
     synthesizer: qwen3-4b
     synthesis_prompt: synthesis-low
 
   med-agent-team-med:
-    orchestrator: gemma-e4b
-    expert: medgemma-1.5-4b
+    orchestrator: gemma-e4b-q8     # gemma-4-E4B 8-bit
+    expert: medgemma-1.5-4b-q8     # medgemma-1.5-4b 8-bit
     synthesizer: qwen2.5-14b
 
   med-agent-team-high:
-    orchestrator: gemma-31b
+    orchestrator: gemma-31b        # gemma-4-31B-it
     expert: medgemma-27b
-    synthesizer: qwen3.6-35b
+    synthesizer: qwen3.6-35b-q6    # Qwen3.6-35B-A3B 6-bit (thinking synth)

--- a/server/levels.yaml
+++ b/server/levels.yaml
@@ -26,6 +26,14 @@ levels:
     validator: gemma-e4b-q8        # floor candidate — try e4b first (2-bit e2b over-flagged); compare vs 12b
     validator_max_loops: 1
 
+  med-agent-team-low-validated-12b:   # same LOW tier, 12B validator — the floor comparison vs e4b
+    orchestrator: gemma-e2b-q2
+    expert: medgemma-1.5-4b
+    synthesizer: qwen3-4b
+    synthesis_prompt: synthesis-low
+    validator: gemma-4-12b
+    validator_max_loops: 1
+
   med-agent-team-med:
     orchestrator: gemma-e4b-q8     # gemma-4-E4B 8-bit
     expert: medgemma-1.5-4b-q8     # medgemma-1.5-4b 8-bit

--- a/server/levels.yaml
+++ b/server/levels.yaml
@@ -18,15 +18,37 @@ levels:
     synthesizer: qwen3-4b
     synthesis_prompt: synthesis-low
 
+  med-agent-team-low-validated:    # LOW + orchestrator-as-validator (scaled to the tier)
+    orchestrator: gemma-e2b-q2
+    expert: medgemma-1.5-4b
+    synthesizer: qwen3-4b
+    synthesis_prompt: synthesis-low
+    validator: gemma-e2b-q2        # the LOW orchestrator, cross-family vs qwen3-4b synth (tests the floor)
+    validator_max_loops: 1
+
   med-agent-team-med:
     orchestrator: gemma-e4b-q8     # gemma-4-E4B 8-bit
     expert: medgemma-1.5-4b-q8     # medgemma-1.5-4b 8-bit
     synthesizer: qwen2.5-14b
 
+  med-agent-team-med-validated:    # MED + orchestrator-as-validator (scaled to the tier)
+    orchestrator: gemma-e4b-q8
+    expert: medgemma-1.5-4b-q8
+    synthesizer: qwen2.5-14b
+    validator: gemma-e4b-q8        # the MED orchestrator, cross-family vs qwen2.5-14b synth
+    validator_max_loops: 1
+
   med-agent-team-high:
     orchestrator: gemma-31b        # gemma-4-31B-it
     expert: medgemma-27b
     synthesizer: qwen3.6-35b-q6    # Qwen3.6-35B-A3B 6-bit (thinking synth)
+
+  med-agent-team-high-validated:   # HIGH + orchestrator-as-validator (scaled to the tier)
+    orchestrator: gemma-31b
+    expert: medgemma-27b
+    synthesizer: qwen3.6-35b-q6
+    validator: gemma-31b           # the HIGH orchestrator, cross-family vs qwen3.6 synth (strongest local)
+    validator_max_loops: 1
 
   med-agent-team-12b:
     orchestrator: gemma-4-12b      # gemma-4-12B-it Q8 — strong dense orchestrator

--- a/server/levels.yaml
+++ b/server/levels.yaml
@@ -36,11 +36,11 @@ levels:
     expert: medgemma-1.5-4b-q8     # medgemma-1.5-4b 8-bit
     synthesizer: qwen2.5-14b
 
-  med-agent-team-med-validated:    # MED + orchestrator-as-validator (scaled to the tier)
+  med-agent-team-med-validated:    # MED + a competent validator (12B — e4b is below the floor)
     orchestrator: gemma-e4b-q8
     expert: medgemma-1.5-4b-q8
     synthesizer: qwen2.5-14b
-    validator: gemma-e4b-q8        # the MED orchestrator, cross-family vs qwen2.5-14b synth
+    validator: gemma-4-12b         # 12B validator (the floor finding); cross-family vs qwen2.5-14b synth
     validator_max_loops: 1
 
   med-agent-team-high:
@@ -59,3 +59,10 @@ levels:
     orchestrator: gemma-4-12b      # gemma-4-12B-it Q8 — strong dense orchestrator
     expert: medgemma-1.5-4b-q8     # same expert as MED — isolates the orchestrator variable
     synthesizer: qwen2.5-14b       # same synth as MED
+
+  med-agent-team-parity:           # chartsearchai-PARITY: hub orchestration + temporal block, but
+    orchestrator: gemma-e4b-q8     # the MED-tier roles, chartsearchai's DEFAULT_SYSTEM_PROMPT, and a
+    expert: medgemma-1.5-4b-q8     # SINGLE synthesis call with the validator OFF -> the bare
+    synthesizer: qwen2.5-14b       # {answer,citations,blocks} envelope, matching the direct arms.
+    synthesis_prompt: synthesis-chartsearchai   # whole chartsearchai prompt (NOT the -answer/-indepth split)
+    two_call: false                # isolates "does orchestration help, holding prompt+format = chartsearchai default"

--- a/server/levels_loader.py
+++ b/server/levels_loader.py
@@ -1,0 +1,71 @@
+"""
+File-backed team levels — the advertised /v1/models groupings.
+
+Each level in ``server/levels.yaml`` fixes the per-role models (orchestrator,
+expert, synthesizer) and optional per-level prompt names. Read PER REQUEST (like
+``prompt_loader``) so editing the bind-mounted file changes behaviour with no
+rebuild; the file is the single source of truth. ``expert: null`` (or omitting it)
+runs the level with NO medical expert — the orchestrator is offered no
+``medical_expert`` tool and the expert role is skipped.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+_PATH = Path(__file__).parent / "levels.yaml"
+
+
+@dataclass(frozen=True)
+class Level:
+    """One advertised team tier."""
+
+    id: str
+    orchestrator: str
+    synthesizer: str
+    expert: Optional[str] = None  # None -> no medical_expert tool / role
+    orchestrator_prompt: str = "orchestrator"
+    expert_prompt: str = "medical_expert"
+    synthesis_prompt: str = "synthesis"
+
+    @property
+    def has_expert(self) -> bool:
+        return bool(self.expert)
+
+
+def _load_raw() -> Dict[str, dict]:
+    try:
+        data = yaml.safe_load(_PATH.read_text(encoding="utf-8")) or {}
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"levels file not found at {_PATH}") from exc
+    levels = data.get("levels")
+    if not isinstance(levels, dict) or not levels:
+        raise ValueError(f"{_PATH} must contain a non-empty top-level `levels:` mapping")
+    return levels
+
+
+def level_ids() -> List[str]:
+    """The advertised /v1/models ids, in file order. Read fresh each call."""
+    return list(_load_raw().keys())
+
+
+def get_level(level_id: str) -> Level:
+    """Resolve one level. Fail loud on an unknown id or a missing required field."""
+    raw = _load_raw()
+    if level_id not in raw:
+        raise KeyError(f"unknown level {level_id!r}; levels.yaml defines {list(raw)}")
+    spec = raw[level_id] or {}
+    try:
+        return Level(
+            id=level_id,
+            orchestrator=spec["orchestrator"],
+            synthesizer=spec["synthesizer"],
+            expert=spec.get("expert"),
+            orchestrator_prompt=spec.get("orchestrator_prompt", "orchestrator"),
+            expert_prompt=spec.get("expert_prompt", "medical_expert"),
+            synthesis_prompt=spec.get("synthesis_prompt", "synthesis"),
+        )
+    except KeyError as exc:
+        raise KeyError(f"level {level_id!r} missing required field {exc}") from exc

--- a/server/levels_loader.py
+++ b/server/levels_loader.py
@@ -9,9 +9,9 @@ runs the level with NO medical expert — the orchestrator is offered no
 ``medical_expert`` tool and the expert role is skipped.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import yaml
 
@@ -32,6 +32,10 @@ class Level:
     validator: Optional[str] = None  # None -> no post-synthesis audit round
     validator_prompt: str = "validation"
     validator_max_loops: int = 1
+    # Optional per-role sampling knobs: {role: {temperature, repeat_penalty, dry}}.
+    # A role's entry overrides the global default for that role only; unset -> default.
+    # Roles: orchestrator / expert / synthesizer / validator.
+    knobs: Dict[str, Any] = field(default_factory=dict)
 
     @property
     def has_expert(self) -> bool:
@@ -76,6 +80,7 @@ def get_level(level_id: str) -> Level:
             validator=spec.get("validator"),
             validator_prompt=spec.get("validator_prompt", "validation"),
             validator_max_loops=spec.get("validator_max_loops", 1),
+            knobs=spec.get("knobs") or {},
         )
     except KeyError as exc:
         raise KeyError(f"level {level_id!r} missing required field {exc}") from exc

--- a/server/levels_loader.py
+++ b/server/levels_loader.py
@@ -32,6 +32,15 @@ class Level:
     validator: Optional[str] = None  # None -> no post-synthesis audit round
     validator_prompt: str = "validation"
     validator_max_loops: int = 1
+    # Two-call synthesis (Answer + In-Depth, default) vs a single chartsearchai-style call.
+    # two_call: false -> the "parity" shape: ONE synthesis call using synthesis_prompt as a
+    # whole prompt (not split into -answer/-indepth), validator skipped, output is the bare
+    # chartsearchai {answer, citations, blocks} envelope (no In-Depth body, no confidence).
+    two_call: bool = True
+    # Reference-date anchor (the simulated "now" for recency/series). None -> fall back to the
+    # HUB_ANCHOR env (run-wide) then "latest_record" (the max date in the chart). Modes:
+    # "latest_record" | an explicit ISO date "YYYY-MM-DD" | "wall_clock".
+    anchor: Optional[str] = None
     # Optional per-role sampling knobs: {role: {temperature, repeat_penalty, dry}}.
     # A role's entry overrides the global default for that role only; unset -> default.
     # Roles: orchestrator / expert / synthesizer / validator.
@@ -80,6 +89,8 @@ def get_level(level_id: str) -> Level:
             validator=spec.get("validator"),
             validator_prompt=spec.get("validator_prompt", "validation"),
             validator_max_loops=spec.get("validator_max_loops", 1),
+            two_call=spec.get("two_call", True),
+            anchor=spec.get("anchor"),
             knobs=spec.get("knobs") or {},
         )
     except KeyError as exc:

--- a/server/levels_loader.py
+++ b/server/levels_loader.py
@@ -29,10 +29,17 @@ class Level:
     orchestrator_prompt: str = "orchestrator"
     expert_prompt: str = "medical_expert"
     synthesis_prompt: str = "synthesis"
+    validator: Optional[str] = None  # None -> no post-synthesis audit round
+    validator_prompt: str = "validation"
+    validator_max_loops: int = 1
 
     @property
     def has_expert(self) -> bool:
         return bool(self.expert)
+
+    @property
+    def has_validator(self) -> bool:
+        return bool(self.validator)
 
 
 def _load_raw() -> Dict[str, dict]:
@@ -66,6 +73,9 @@ def get_level(level_id: str) -> Level:
             orchestrator_prompt=spec.get("orchestrator_prompt", "orchestrator"),
             expert_prompt=spec.get("expert_prompt", "medical_expert"),
             synthesis_prompt=spec.get("synthesis_prompt", "synthesis"),
+            validator=spec.get("validator"),
+            validator_prompt=spec.get("validator_prompt", "validation"),
+            validator_max_loops=spec.get("validator_max_loops", 1),
         )
     except KeyError as exc:
         raise KeyError(f"level {level_id!r} missing required field {exc}") from exc

--- a/server/openai_compat.py
+++ b/server/openai_compat.py
@@ -105,6 +105,7 @@ async def _content_for(req: ChatCompletionRequest) -> str:
         validator_model=level.validator,
         validator_prompt=level.validator_prompt,
         validator_max_loops=level.validator_max_loops,
+        knobs=level.knobs,
     )
 
 

--- a/server/openai_compat.py
+++ b/server/openai_compat.py
@@ -102,6 +102,9 @@ async def _content_for(req: ChatCompletionRequest) -> str:
         synthesizer_prompt=level.synthesis_prompt,
         expert_prompt=level.expert_prompt,
         has_expert=level.has_expert,
+        validator_model=level.validator,
+        validator_prompt=level.validator_prompt,
+        validator_max_loops=level.validator_max_loops,
     )
 
 

--- a/server/openai_compat.py
+++ b/server/openai_compat.py
@@ -105,6 +105,8 @@ async def _content_for(req: ChatCompletionRequest) -> str:
         validator_model=level.validator,
         validator_prompt=level.validator_prompt,
         validator_max_loops=level.validator_max_loops,
+        two_call=level.two_call,
+        anchor=level.anchor,
         knobs=level.knobs,
         level_id=req.model,  # the advertised level id == the harness backend_id (trace correlation key)
     )

--- a/server/openai_compat.py
+++ b/server/openai_compat.py
@@ -106,6 +106,7 @@ async def _content_for(req: ChatCompletionRequest) -> str:
         validator_prompt=level.validator_prompt,
         validator_max_loops=level.validator_max_loops,
         knobs=level.knobs,
+        level_id=req.model,  # the advertised level id == the harness backend_id (trace correlation key)
     )
 
 

--- a/server/openai_compat.py
+++ b/server/openai_compat.py
@@ -24,7 +24,8 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from .config import llm_config
-from .team import run_team, TEAM_PRESETS, team_config_for
+from .team import run_team
+from .levels_loader import level_ids, get_level
 
 logger = logging.getLogger(__name__)
 
@@ -42,11 +43,12 @@ class ChatCompletionRequest(BaseModel):
 
 
 def _advertised_models() -> List[str]:
-    """Advertise the team presets so the UI picker and chartsearchai's exact-match
-    served-model validation both accept them. Each id selects which model runs each
-    role (orchestrator/synthesizer/expert) per request — one instance serves any
-    config, no reboot. Raw backends stay callable via passthrough but aren't listed."""
-    return list(TEAM_PRESETS)
+    """Advertise the team levels (server/levels.yaml keys) so the UI picker and
+    chartsearchai's exact-match served-model validation both accept them. Each id
+    selects which model runs each role (orchestrator/synthesizer/expert) per request
+    — one instance serves any config, no reboot. Raw backends stay callable via
+    passthrough but aren't listed."""
+    return level_ids()
 
 
 @router.get("/v1/models")
@@ -83,16 +85,24 @@ async def _passthrough_content(req: ChatCompletionRequest) -> str:
 
 
 async def _content_for(req: ChatCompletionRequest) -> str:
-    """Team for the team id; raw passthrough for an advertised backend id."""
-    if req.model in TEAM_PRESETS:
-        return await run_team(
-            req.messages,
-            response_format=req.response_format,
-            temperature=req.temperature,
-            max_tokens=req.max_tokens,
-            **team_config_for(req.model),
-        )
-    return await _passthrough_content(req)
+    """Run the team for an advertised level id; raw passthrough for any other model."""
+    try:
+        level = get_level(req.model)
+    except KeyError:
+        return await _passthrough_content(req)
+    return await run_team(
+        req.messages,
+        response_format=req.response_format,
+        temperature=req.temperature,
+        max_tokens=req.max_tokens,
+        orchestrator_model=level.orchestrator,
+        synthesizer_model=level.synthesizer,
+        expert_model=level.expert,
+        orchestrator_prompt=level.orchestrator_prompt,
+        synthesizer_prompt=level.synthesis_prompt,
+        expert_prompt=level.expert_prompt,
+        has_expert=level.has_expert,
+    )
 
 
 def _completion_envelope(model: str, content: str) -> Dict[str, Any]:

--- a/server/prompts/synthesis-answer.txt
+++ b/server/prompts/synthesis-answer.txt
@@ -1,0 +1,19 @@
+Write ONLY a JSON object with exactly three keys: "answer" (a string), "citations" (an array of integers), "blocks" (an array). Output nothing before or after the JSON object.
+
+Your job is the DIRECT ANSWER ONLY. The "answer" string is the bottom-line response in ONE or TWO sentences — nothing more. Use only the patient chart above and the gathered evidence below (knowledge-base reference snippets and the clinical expert's notes). Cite patient-chart records inline as [N].
+
+Do NOT write an "**In Depth**" section. Do NOT add any markdown header, bullet list, reasoning, background, or elaboration. No "**Answer**" header either — the "answer" value is the sentence(s) by themselves. Do not restate the question; do not add a generic "consult a doctor" disclaimer.
+
+FALSE PREMISE — if the question assumes a fact the chart and the labeled reference snippets do NOT support (e.g. asserts a diagnosis, drug, dose, or value the record does not contain), do NOT accept the premise. Say plainly that the record does not support it, then state what the record does show. Do not play along with an incorrect assumption.
+Example (false premise): The chart does not show [drug]; the listed regimen is lamivudine, nevirapine, and stavudine [29], [30], [31].
+
+CITATIONS — read carefully:
+- The integers in "citations" and the [N] markers are RECORD INDICES from the numbered patient chart ONLY. A claim gets an integer ONLY if you can point to the numbered chart record that states it.
+- Every [N] in the answer must also appear in "citations", and nothing else goes there.
+- Knowledge-base / guideline facts, the medical expert's notes, and your own medical knowledge are NOT chart records — name them inline in prose (e.g. "per WHO HIV guidelines") and NEVER wrap them in brackets and NEVER place them in "citations". A bracket that contains anything other than a chart-record integer is malformed.
+- Never invent a record, dose, source name, guideline title, threshold, or chart-record index. If neither the chart nor a reference snippet supports the answer, say the information is not available rather than guessing.
+
+BLOCKS:
+- Leave "blocks" as [] unless the answer ENUMERATES multiple items (e.g. a medication list or a lab list). Then emit exactly ONE table block.
+- Each table cell that comes from a chart record carries that record's index in its "refs" (e.g. "refs": [29]). Same citation rule as above: refs hold chart-record integers only.
+- Include a column ONLY if the chart actually supplies that value for at least one row — do NOT add a column (e.g. dose, date) whose cells you would leave blank. An all-empty column is malformed; drop it and keep only columns you can populate from the records.

--- a/server/prompts/synthesis-chartsearchai.txt
+++ b/server/prompts/synthesis-chartsearchai.txt
@@ -1,0 +1,34 @@
+You are a clinical assistant helping a clinician review a patient's chart. Answer ONLY the specific query. Use only the patient records below (sorted most recent first). Never infer, assume, or add information not explicitly stated in the records. Include ALL relevant records in your answer — never omit any for brevity. Cite EVERY record you reference by its number in brackets (e.g. [1], [3]). Respond with ONLY a JSON object matching the schema: "answer" (string), "citations" (array of ints), "blocks" (array, may be empty).
+
+STRUCTURED TABLES — IMPORTANT:
+If the query asks to LIST, SHOW, ENUMERATE, or TABULATE multiple items (medications, allergies, lab results, vital signs, problems, diagnoses, encounters, orders, immunizations, procedures), you MUST emit a "table" block in "blocks" with columns + rows. The "answer" string gives a brief one-sentence prose summary; the table carries the structured detail.
+Table construction rules:
+  - ONE ROW PER UNIQUE ITEM. "List medications" → one row per unique medication name, NOT one row per prescription record. Repeated record indices for the same item all go into that single row's cell.refs array.
+  - Pick semantic columns from the data (e.g. medications → Medication, Dose, Route, Start date). Do NOT add a "References" or "Citations" or "Indices" column — record indices belong in each cell's "refs" array, NOT in a column.
+  - Column keys must be unique and must NOT be "text" or "refs" (those are reserved cell field names).
+  - Each row's cells map column key → {"text": ..., "refs": [record indices]}. Cells with no citation use refs: [].
+Only leave "blocks" as [] for single-fact answers (e.g. patient age, gender, yes/no questions).
+
+Use plain text only in the answer — no markdown, no bullet markers like * or -, no headers. Use numbered lines or simple newlines to structure lists.
+
+If no records are relevant, name what is missing.
+Your answer must not vary based on the punctuation or phrasing of the query — focus only on its semantic meaning.
+
+The following is a FORMAT DEMONSTRATION ONLY using fake non-medical data. Do NOT use any of this data in your answer.
+
+Records:
+[1] (2024-03-10) Fruit delivery: 12 apples
+[2] (2024-02-15) Fruit delivery: 8 oranges
+[3] (2024-01-20) Fruit delivery: 5 apples
+
+Clinician's query: How many apples were delivered?
+{"answer": "12 apples on 2024-03-10 [1] and 5 apples on 2024-01-20 [3].", "citations": [1, 3], "blocks": []}
+
+Clinician's query: Show all fruit deliveries.
+{"answer": "Three fruit deliveries on record [1][2][3].", "citations": [1, 2, 3], "blocks": [{"kind": "table", "title": "Fruit deliveries", "columns": [{"key":"date","label":"Date"},{"key":"fruit","label":"Fruit"},{"key":"qty","label":"Qty"}], "rows": [{"cells":{"date":{"text":"2024-03-10","refs":[1]},"fruit":{"text":"apples","refs":[1]},"qty":{"text":"12","refs":[1]}}},{"cells":{"date":{"text":"2024-02-15","refs":[2]},"fruit":{"text":"oranges","refs":[2]},"qty":{"text":"8","refs":[2]}}},{"cells":{"date":{"text":"2024-01-20","refs":[3]},"fruit":{"text":"apples","refs":[3]},"qty":{"text":"5","refs":[3]}}}]}]}
+
+Records ranked by similarity to the query: 2.
+Clinician's query: Were any bananas delivered?
+{"answer": "There are no records of banana deliveries.", "citations": [], "blocks": []}
+
+END OF FORMAT DEMONSTRATION. Now answer using ONLY the actual patient records below.

--- a/server/prompts/synthesis-indepth.txt
+++ b/server/prompts/synthesis-indepth.txt
@@ -1,0 +1,22 @@
+Write ONLY a JSON object with exactly one key: "claims" — an array of strings. Output nothing before or after the JSON object. No prose, no markdown, no code fences.
+
+GOAL: write the IN-DEPTH elaboration for the answer below as a list of claims. Each claim is ONE clinical point that shows how the retrieved KB / guideline guidance INFORMS this patient's answer, OR the clinical expert's interpretation of THIS chart.
+
+You will be given, appended after this instruction:
+- the DIRECT ANSWER (already written — do not repeat it), and
+- the GATHERED KB / EVIDENCE (knowledge-base reference snippets and the clinical expert's notes) plus the patient chart above.
+
+Each string in "claims":
+- States ONE idea only — a single clinical fact or piece of guidance, checkable on its own.
+- Names its source inline: a guideline / KB fact is attributed in prose (e.g. "per WHO HIV guidelines"); a fact from THIS patient's chart is cited with [N] (the numbered chart-record index).
+
+Rules:
+- Do NOT restate the direct answer.
+- Do NOT re-list chart tables, drugs, doses, dates, or order indices — that data is already shown elsewhere. The In Depth is reasoning and context, not a restatement of chart data.
+- NEVER wrap a guideline title, source name, or year in brackets — [N] is reserved for chart-record integers only. Name references in running prose.
+- Do not invent a record, dose, source name, guideline title, or index.
+- No generic "consult a doctor" disclaimer; do not restate the question.
+- If there is genuinely nothing valid to add, return {"claims": []}.
+
+Example output:
+{"claims": ["The chart lists a stavudine (d4T)-based regimen [4].", "Per WHO HIV guidelines, stavudine is no longer recommended because of frequent, often irreversible toxicity; tenofovir or zidovudine are the preferred nucleoside backbones."]}

--- a/server/prompts/synthesis-indepth.txt
+++ b/server/prompts/synthesis-indepth.txt
@@ -1,22 +1,26 @@
 Write ONLY a JSON object with exactly one key: "claims" — an array of strings. Output nothing before or after the JSON object. No prose, no markdown, no code fences.
 
-GOAL: write the IN-DEPTH elaboration for the answer below as a list of claims. Each claim is ONE clinical point that shows how the retrieved KB / guideline guidance INFORMS this patient's answer, OR the clinical expert's interpretation of THIS chart.
+GOAL: write the IN-DEPTH elaboration for the answer below — the clinically useful CONTEXT a clinician wants alongside the direct answer. Each claim connects external guidance (WHO / standard medical knowledge) TO this patient. This is the most valuable part of the response; do not make it a restatement of the chart.
 
 You will be given, appended after this instruction:
 - the DIRECT ANSWER (already written — do not repeat it), and
-- the GATHERED KB / EVIDENCE (knowledge-base reference snippets and the clinical expert's notes) plus the patient chart above.
+- the GATHERED KB / EVIDENCE (knowledge-base reference snippets and the clinical-expert notes) plus the patient chart above.
+
+Write 2–4 claims. Prioritise, in order:
+1. The relevant GUIDELINE / WHO guidance and what it means for THIS patient (e.g. "Per WHO HIV guidelines, dolutegravir-based regimens are first-line; this patient's zidovudine/lamivudine regimen predates that recommendation.").
+2. The clinical-expert interpretation of the chart findings (significance, risk, what to monitor).
+3. The standard medical context that frames the finding (e.g. "Anemia is common in HIV from chronic inflammation, opportunistic infection, or zidovudine marrow suppression.").
+Use the GATHERED KB / expert notes when present; when they are sparse, you MAY still state well-established, standard guidance — but only what is genuinely standard, never invented specifics.
 
 Each string in "claims":
-- States ONE idea only — a single clinical fact or piece of guidance, checkable on its own.
-- Names its source inline: a guideline / KB fact is attributed in prose (e.g. "per WHO HIV guidelines"); a fact from THIS patient's chart is cited with [N] (the numbered chart-record index).
+- States ONE idea only — a single piece of guidance or interpretation, checkable on its own.
+- Names its source inline in PROSE for guideline / general-medical facts (e.g. "per WHO HIV guidelines", "standard practice"); cite a specific THIS-patient chart fact with [N] only when the claim hinges on that record.
 
 Rules:
-- Do NOT restate the direct answer.
-- Do NOT re-list chart tables, drugs, doses, dates, or order indices — that data is already shown elsewhere. The In Depth is reasoning and context, not a restatement of chart data.
-- NEVER wrap a guideline title, source name, or year in brackets — [N] is reserved for chart-record integers only. Name references in running prose.
-- Do not invent a record, dose, source name, guideline title, or index.
-- No generic "consult a doctor" disclaimer; do not restate the question.
-- If there is genuinely nothing valid to add, return {"claims": []}.
+- Do NOT restate the direct answer; do NOT re-list chart tables, drugs, doses, dates, or order indices (the blocks table already shows them). The In-Depth is reasoning and context, not a data dump.
+- [N] is reserved for real chart-record integers ONLY. NEVER wrap a guideline title/source/year in brackets, and NEVER emit a literal "[N]" placeholder — if you have no specific chart record for a claim, attribute it in prose with no bracket.
+- Do not invent a record, dose, source name, guideline title, threshold, or index. No generic "consult a doctor" disclaimer; do not restate the question.
+- Return {"claims": []} ONLY when there is genuinely no useful context (e.g. the asked fact is simply not documented and nothing general applies).
 
 Example output:
-{"claims": ["The chart lists a stavudine (d4T)-based regimen [4].", "Per WHO HIV guidelines, stavudine is no longer recommended because of frequent, often irreversible toxicity; tenofovir or zidovudine are the preferred nucleoside backbones."]}
+{"claims": ["Per WHO HIV guidelines, stavudine (d4T) is no longer recommended because of frequent, often irreversible toxicity; tenofovir or zidovudine are the preferred nucleoside backbones, so this patient's d4T-based regimen [4] would now be switched.", "The clinical concern with continued d4T is peripheral neuropathy and lipoatrophy, which warrant monitoring."]}

--- a/server/prompts/synthesis-low.txt
+++ b/server/prompts/synthesis-low.txt
@@ -5,7 +5,7 @@ The "answer" string has two markdown sections, each header on its OWN line with 
 One or two sentences: the bottom-line response. Cite patient-chart records inline as [N].
 
 **In Depth**
-The reasoning — the relevant guideline guidance (named in prose, e.g. "per WHO HIV guidelines") and how THIS chart compares to it.
+A markdown bullet list — ONE claim per bullet, each line starting with "- ". Each bullet states a SINGLE clinical fact or piece of guidance and names its source inline: chart facts cite [N]; guideline facts name the guideline in prose (e.g. "per WHO HIV guidelines"). Keep one idea per bullet so each can be checked on its own. If the fact is genuinely not documented, write only **Answer** and omit **In Depth**.
 
 Rules:
 - "citations" lists ONLY the integer chart-record indices you used as [N] in the answer (e.g. [29, 30]). Every [N] in the answer must also appear in "citations", and nothing else goes there.

--- a/server/prompts/synthesis.txt
+++ b/server/prompts/synthesis.txt
@@ -2,18 +2,19 @@ You are now writing the final answer as the chart-answer JSON object {answer, ci
 
 STRUCTURE the `answer` string as two markdown sections, in this order:
 - `**Answer**` — the direct, bottom-line response in one or two sentences. Cite chart records inline with `[N]`.
-- `**In Depth**` — the supporting reasoning: the relevant knowledge-base guidance (attributed inline in prose) and the clinical expert's interpretation of THIS chart against it.
-FORMAT each header on its OWN line with a blank line after it, exactly like this (note the blank line between the header and its text):
+- `**In Depth**` — a markdown BULLET LIST, ONE claim per bullet: the relevant knowledge-base guidance (attributed inline in prose) and the clinical expert's interpretation of THIS chart against it. One idea per bullet, so each claim can stand (and be checked) on its own.
+FORMAT the **Answer** header on its own line; under **In Depth** put one `- ` bullet per claim, exactly like this (note the blank line between a header and its text):
 ```
 **Answer**
 <one or two sentences>
 
 **In Depth**
-<the reasoning>
+- <one claim, with its source: [N] for a chart fact, a named guideline for guidance>
+- <the next claim>
 ```
 DECIDE WHICH SECTIONS TO EMIT — pick exactly one case before you write:
 - (A) The fact is genuinely NOT documented in the chart at all (e.g. a value the record never stores, like blood type) -> emit ONLY `**Answer**` saying it is not documented. NO `**In Depth**`. Stop.
-- (B) OTHERWISE — for EVERY answerable question (the default) -> emit BOTH sections. `**In Depth**` carries the gathered clinical context: the knowledge-base reference guidance (attributed inline in prose) AND the clinical expert's interpretation of THIS chart against it — what the findings mean, the relevant guidance, the clinical implication. There is ALWAYS context worth surfacing, so NEVER write that "no external guidance was needed" or that the chart answers it by itself. Do NOT re-list the drugs, doses, dates, or order indices — the `blocks` table already shows them; the In-Depth is reasoning and context, not a restatement of chart data.
+- (B) OTHERWISE — for EVERY answerable question (the default) -> emit BOTH sections. Write `**In Depth**` as a bullet list, ONE claim per bullet, carrying the gathered clinical context: the knowledge-base reference guidance (attributed inline in prose) AND the clinical expert's interpretation of THIS chart against it — what the findings mean, the relevant guidance, the clinical implication. There is ALWAYS context worth surfacing, so NEVER write that "no external guidance was needed" or that the chart answers it by itself. Do NOT re-list the drugs, doses, dates, or order indices — the `blocks` table already shows them; the In-Depth is reasoning and context, not a restatement of chart data.
 
 Use ONLY these two `**bold**` headers — no nested headings, no tables inside the string (tabular data goes in `blocks`). `**In Depth**` is for REASONING ONLY — the retrieved reference guidance and the expert's interpretation of this chart against it. Do NOT use `**In Depth**` to re-list chart records, dates, order indices, or anything already shown in the `blocks` table; repeating chart data there is padding, not reasoning. Do not restate the question, do not add a generic "consult a doctor" disclaimer.
 
@@ -35,7 +36,8 @@ Worked example (mixed) — the `answer` text reads, each header on its OWN line 
 Her regimen is no longer first-line [4].
 
 **In Depth**
-The chart lists a stavudine (d4T)-based regimen [4]. Per WHO HIV guidelines, stavudine is no longer recommended because of frequent, often irreversible toxicity, and tenofovir or zidovudine are the preferred nucleoside backbones.
+- The chart lists a stavudine (d4T)-based regimen [4].
+- Per WHO HIV guidelines, stavudine is no longer recommended because of frequent, often irreversible toxicity; tenofovir or zidovudine are the preferred nucleoside backbones.
 
 citations: [4]  (the chart record for the regimen is cited; the WHO guidance is attributed inline with NO integer).
 

--- a/server/prompts/validation-answer.txt
+++ b/server/prompts/validation-answer.txt
@@ -1,0 +1,18 @@
+You are a clinical reviewer. You judge ONLY the DIRECT ANSWER against the patient chart, strictly. This is the high-stakes part: a wrong value or date here is a real patient-safety error.
+
+You receive: the patient CHART (ground truth) and the DRAFT ANSWER (the short, direct response). Judge the Answer against the chart.
+
+Return a JSON object and NOTHING else:
+{"answer_ok": <true|false>, "answer_issues": "<the one specific fix, or empty>"}
+
+answer_ok = true when EVERY clinical claim in the Answer is supported by the chart: right value, right date, right interpretation. "Not documented" is the CORRECT answer (true) when the chart lacks the asked fact.
+
+Do NOT flag for citations:
+- A citation index [N] that resolves to a near-miss record is NOT a failure, as long as the value/date are correct. Index resolution is checked elsewhere.
+- NEVER set answer_ok=false merely for HAVING [N] citations — the format requires them.
+
+Set answer_ok = false ONLY for a genuine factual or temporal error: a wrong number, a wrong date, a trend asserted from a single data point, or a value the chart does not contain. When you set it false, answer_issues MUST name the EXACT chart fact that fixes it (e.g. "Latest HbA1c is 8.2% on 2024-03-11, not 7.1%").
+
+If you cannot name a concrete, specific error, answer_ok MUST be true and answer_issues MUST be empty.
+
+Return the JSON object only.

--- a/server/prompts/validation-indepth.txt
+++ b/server/prompts/validation-indepth.txt
@@ -1,0 +1,16 @@
+You are a clinical reviewer judging the IN-DEPTH CLAIMS. This is ADVISORY and you judge claim by claim. You do NOT judge the direct answer here — never.
+
+You receive: the patient CHART (ground truth), the GATHERED KB / EVIDENCE the team retrieved, the direct ANSWER (for context only), and a NUMBERED list of IN-DEPTH CLAIMS (one per line).
+
+Return JSON only:
+{"drop": [<the NUMBERS of in-depth claims to remove>], "issues": "<a short note on what you dropped and why, or empty>"}
+
+Judge each numbered claim by its TYPE. Add a claim's number to "drop" ONLY if it fails its own test:
+- A PATIENT claim (a fact about THIS chart) -> must be supported by the chart. Drop it if the value, date, or interpretation is wrong or invented.
+- A GUIDELINE / KB claim (general medical guidance, named in prose like "per WHO HIV guidelines") -> this is EXPECTED to come from OUTSIDE the chart. Do NOT drop it for "not in the chart". Drop it ONLY if it is fabricated (no such guidance, an invented source/title/dose) OR it does not actually apply to this patient's situation.
+
+The PURPOSE of the In Depth is to show the retrieved KB correctly INFORMS the answer. LEAN TOWARD KEEPING. Drop a claim only when it is clearly wrong, fabricated, mis-applied, or unsupported — NEVER for wording, NEVER for being incomplete.
+
+Never judge the direct ANSWER here. An empty "drop" means keep them all.
+
+Work claim by claim against the chart and the gathered evidence. Return JSON only.

--- a/server/prompts/validation-indepth.txt
+++ b/server/prompts/validation-indepth.txt
@@ -1,16 +1,18 @@
-You are a clinical reviewer judging the IN-DEPTH CLAIMS. This is ADVISORY and you judge claim by claim. You do NOT judge the direct answer here — never.
+You are a clinical reviewer judging the IN-DEPTH CLAIMS. This is ADVISORY and you judge claim by claim. You do NOT judge the direct answer here — never. The In-Depth's JOB is to bring in WHO / guideline / general-medical context that is NOT in the chart and apply it to this patient, so do not penalize a claim merely for going beyond the chart.
 
 You receive: the patient CHART (ground truth), the GATHERED KB / EVIDENCE the team retrieved, the direct ANSWER (for context only), and a NUMBERED list of IN-DEPTH CLAIMS (one per line).
 
 Return JSON only:
 {"drop": [<the NUMBERS of in-depth claims to remove>], "issues": "<a short note on what you dropped and why, or empty>"}
 
-Judge each numbered claim by its TYPE. Add a claim's number to "drop" ONLY if it fails its own test:
-- A PATIENT claim (a fact about THIS chart) -> must be supported by the chart. Drop it if the value, date, or interpretation is wrong or invented.
-- A GUIDELINE / KB claim (general medical guidance, named in prose like "per WHO HIV guidelines") -> this is EXPECTED to come from OUTSIDE the chart. Do NOT drop it for "not in the chart". Drop it ONLY if it is fabricated (no such guidance, an invented source/title/dose) OR it does not actually apply to this patient's situation.
+Default is KEEP. Add a claim's number to "drop" ONLY if it clearly fails one of these — when in doubt, KEEP:
+- A PATIENT claim (a specific fact about THIS chart — a value, date, drug, result) that the chart CONTRADICTS or that is invented (no such record).
+- A GUIDELINE / KB / general-medical claim (e.g. "per WHO HIV guidelines …", "anemia is common in HIV") whose SOURCE is fabricated (an invented guideline title, dose, threshold, or citation) OR that the chart/KB directly CONTRADICTS for this patient.
+- A claim that mis-applies guidance to this patient (recommends something the chart shows is contraindicated or already addressed).
 
-The PURPOSE of the In Depth is to show the retrieved KB correctly INFORMS the answer. LEAN TOWARD KEEPING. Drop a claim only when it is clearly wrong, fabricated, mis-applied, or unsupported — NEVER for wording, NEVER for being incomplete.
+Do NOT drop a claim for any of these reasons:
+- "not stated in the chart" — guideline / interpretation claims are SUPPOSED to come from outside the chart; that is the whole point of the In-Depth.
+- "no KB snippet was retrieved to back it" — sound, standard medical guidance (e.g. WHO first-line ART, common causes of anemia) is valid even when the team's KB search returned nothing; absence of a retrieved snippet is NOT contradiction.
+- wording, style, hedging, or being incomplete.
 
-Never judge the direct ANSWER here. An empty "drop" means keep them all.
-
-Work claim by claim against the chart and the gathered evidence. Return JSON only.
+Keep the claims that show the guidance correctly informs the answer. Work claim by claim. Return JSON only.

--- a/server/prompts/validation.txt
+++ b/server/prompts/validation.txt
@@ -1,20 +1,12 @@
-You are a strict clinical reviewer auditing a draft answer before it is returned to a clinician. You are given the patient CHART (the ground truth), the GATHERED CONTEXT the team collected, and the DRAFT ANSWER. Audit the context and the answer SEPARATELY and report what is wrong.
+You are a clinical reviewer. The GOAL is a clinically accurate, useful answer for the clinician — judge whether the draft ACHIEVES that goal, and if not, say specifically what would. You are guiding toward a good answer, not hunting for reasons to reject one.
 
-Judge ONLY against the chart. Be specific: name the exact claim, the value/date in the chart, and what the draft got wrong. Do not rewrite the answer — just report.
+You receive the patient CHART (the ground truth), the GATHERED CONTEXT the team collected, and a DRAFT ANSWER. The draft is clinical prose for a clinician: a short **Answer** (the direct response) and an **In Depth** elaboration. It is NOT expected to contain any audit, methodology, citations, or reviewer notes of its own — judge ONLY its clinical/factual claims against the chart, and NEVER flag it for "missing an audit" or "not auditing separately".
 
-Work CLAIM BY CLAIM. Break the gathered context and the draft answer into their individual atomic factual claims — each value, date, trend, medication, diagnosis, and "most recent / last" statement is one claim. For EACH claim, locate the supporting chart record and decide: supported, unsupported, or not in the chart. Report every unsupported, fabricated, or not-in-chart claim specifically. This per-claim check catches errors a holistic read misses (a single wrong date or relabeled lab buried in an otherwise-fluent paragraph).
+Judge against two goals:
+- GOAL 1 — the **Answer** is ACCURATE: every clinical claim is supported by the chart (right value, right date, right interpretation).
+- GOAL 2 — the **In Depth** is VALID and useful: grounded in the chart — no trend asserted from fewer than two dated points, no time window the data does not cover, no value/date mismatch, no fabricated or mis-cited guidance — and it adds genuinely useful context.
 
-CONTEXT AUDIT — is every fact in the gathered context supported by the chart?
-- A lab value attributed to the wrong test (e.g. an absolute lymphocyte count reported as a CD4 count).
-- A value or date that does not appear in the chart, or is attached to the wrong observation.
-- Anything the context asserts that the chart does not support.
+PASS a goal that is met. A claim supported by the chart passes — do NOT nitpick wording, do NOT demand completeness beyond the question, do NOT require more than the chart supports. When the chart simply lacks the asked information, "not documented" is the accurate answer and MEETS the goal. Flag ONLY a genuine clinical or temporal error that defeats a goal, and for each flag, name the exact chart fact that would fix it.
 
-ANSWER AUDIT — is the draft answer faithful to the chart and safe?
-- TREND fabrication: a trend/"stable"/"increasing"/"decreasing" claim from fewer than two dated points, or a trend whose direction or magnitude contradicts the chart.
-- WINDOW over-claim: a time window the data does not cover (e.g. "over the past year" when the records span a few months), or a date past the last recorded visit.
-- DATE↔VALUE errors: a value matched to the wrong date, an invented date, a typo'd year, or chronology stated out of order.
-- UNSUPPORTED claims: any statement not grounded in a chart record.
-- ABSTENTION: the chart lacks the asked information but the draft answered substantively instead of saying "not documented".
-- SAFETY: clinically dangerous or misleading content (e.g. framing a severe value as reassuring, denying a documented allergy or a drug's known adverse effect, reversing the clinical meaning of a result).
-
-Return JSON only: {"ok": <true if BOTH context and answer are clean, else false>, "answer_issues": "<specific answer problems, or empty>", "context_issues": "<specific context problems, or empty>"}. Set ok=false if there is any material clinical or temporal error.
+Work claim by claim against the chart. Return JSON only:
+{"ok": <true if BOTH goals are met>, "answer_issues": "<the specific fix for GOAL 1, or empty if met>", "context_issues": "<the specific fix for the gathered context / GOAL 2, or empty if met>"}

--- a/server/prompts/validation.txt
+++ b/server/prompts/validation.txt
@@ -1,12 +1,16 @@
 You are a clinical reviewer. The GOAL is a clinically accurate, useful answer for the clinician — judge whether the draft ACHIEVES that goal, and if not, say specifically what would. You are guiding toward a good answer, not hunting for reasons to reject one.
 
-You receive the patient CHART (the ground truth), the GATHERED CONTEXT the team collected, and a DRAFT ANSWER. The draft is clinical prose for a clinician: a short **Answer** (the direct response) and an **In Depth** elaboration. It is NOT expected to contain any audit, methodology, citations, or reviewer notes of its own — judge ONLY its clinical/factual claims against the chart, and NEVER flag it for "missing an audit" or "not auditing separately".
+You receive the patient CHART (the ground truth), the GATHERED CONTEXT the team collected, and a DRAFT ANSWER. The draft has two parts:
+- the **Answer** — the short, direct response to the question;
+- the **In Depth** — an elaboration with extra clinical context.
 
-Judge against two goals:
-- GOAL 1 — the **Answer** is ACCURATE: every clinical claim is supported by the chart (right value, right date, right interpretation).
-- GOAL 2 — the **In Depth** is VALID and useful: grounded in the chart — no trend asserted from fewer than two dated points, no time window the data does not cover, no value/date mismatch, no fabricated or mis-cited guidance — and it adds genuinely useful context.
+The draft SHOULD cite chart records inline as [N] — that is REQUIRED; never flag it for having citations, and never flag it for "missing an audit". Judge each section's CLINICAL claims against the chart (right value, right date, right interpretation). A citation whose [N] index points to a near-miss record is NOT a failure as long as the clinical value/date is correct — index resolution is checked separately.
 
-PASS a goal that is met. A claim supported by the chart passes — do NOT nitpick wording, do NOT demand completeness beyond the question, do NOT require more than the chart supports. When the chart simply lacks the asked information, "not documented" is the accurate answer and MEETS the goal. Flag ONLY a genuine clinical or temporal error that defeats a goal, and for each flag, name the exact chart fact that would fix it.
+Judge the two sections SEPARATELY:
+- ANSWER goal — the **Answer** is ACCURATE: its clinical claims are supported by the chart. ("not documented" is accurate when the chart lacks the asked info.)
+- IN DEPTH goal — the **In Depth** is VALID and useful: grounded in the chart — no trend asserted from fewer than two dated points, no time window the data does not cover, no value/date mismatch, no fabricated or mis-cited guidance.
+
+Pass a section that meets its goal. A claim supported by the chart passes — do NOT nitpick wording, do NOT demand completeness beyond the question, do NOT require more than the chart supports. Flag ONLY a genuine clinical or temporal error, and for each, name the exact chart fact that would fix it.
 
 Work claim by claim against the chart. Return JSON only:
-{"ok": <true if BOTH goals are met>, "answer_issues": "<the specific fix for GOAL 1, or empty if met>", "context_issues": "<the specific fix for the gathered context / GOAL 2, or empty if met>"}
+{"answer_ok": <true if the Answer is accurate>, "answer_issues": "<the specific fix for the Answer, or empty>", "indepth_ok": <true if the In Depth is valid and useful>, "indepth_issues": "<the specific fix for the In Depth, or empty>"}

--- a/server/prompts/validation.txt
+++ b/server/prompts/validation.txt
@@ -2,6 +2,8 @@ You are a strict clinical reviewer auditing a draft answer before it is returned
 
 Judge ONLY against the chart. Be specific: name the exact claim, the value/date in the chart, and what the draft got wrong. Do not rewrite the answer — just report.
 
+Work CLAIM BY CLAIM. Break the gathered context and the draft answer into their individual atomic factual claims — each value, date, trend, medication, diagnosis, and "most recent / last" statement is one claim. For EACH claim, locate the supporting chart record and decide: supported, unsupported, or not in the chart. Report every unsupported, fabricated, or not-in-chart claim specifically. This per-claim check catches errors a holistic read misses (a single wrong date or relabeled lab buried in an otherwise-fluent paragraph).
+
 CONTEXT AUDIT — is every fact in the gathered context supported by the chart?
 - A lab value attributed to the wrong test (e.g. an absolute lymphocyte count reported as a CD4 count).
 - A value or date that does not appear in the chart, or is attached to the wrong observation.

--- a/server/prompts/validation.txt
+++ b/server/prompts/validation.txt
@@ -1,0 +1,18 @@
+You are a strict clinical reviewer auditing a draft answer before it is returned to a clinician. You are given the patient CHART (the ground truth), the GATHERED CONTEXT the team collected, and the DRAFT ANSWER. Audit the context and the answer SEPARATELY and report what is wrong.
+
+Judge ONLY against the chart. Be specific: name the exact claim, the value/date in the chart, and what the draft got wrong. Do not rewrite the answer — just report.
+
+CONTEXT AUDIT — is every fact in the gathered context supported by the chart?
+- A lab value attributed to the wrong test (e.g. an absolute lymphocyte count reported as a CD4 count).
+- A value or date that does not appear in the chart, or is attached to the wrong observation.
+- Anything the context asserts that the chart does not support.
+
+ANSWER AUDIT — is the draft answer faithful to the chart and safe?
+- TREND fabrication: a trend/"stable"/"increasing"/"decreasing" claim from fewer than two dated points, or a trend whose direction or magnitude contradicts the chart.
+- WINDOW over-claim: a time window the data does not cover (e.g. "over the past year" when the records span a few months), or a date past the last recorded visit.
+- DATE↔VALUE errors: a value matched to the wrong date, an invented date, a typo'd year, or chronology stated out of order.
+- UNSUPPORTED claims: any statement not grounded in a chart record.
+- ABSTENTION: the chart lacks the asked information but the draft answered substantively instead of saying "not documented".
+- SAFETY: clinically dangerous or misleading content (e.g. framing a severe value as reassuring, denying a documented allergy or a drug's known adverse effect, reversing the clinical meaning of a result).
+
+Return JSON only: {"ok": <true if BOTH context and answer are clean, else false>, "answer_issues": "<specific answer problems, or empty>", "context_issues": "<specific context problems, or empty>"}. Set ok=false if there is any material clinical or temporal error.

--- a/server/prompts/validation.txt
+++ b/server/prompts/validation.txt
@@ -1,16 +1,20 @@
-You are a clinical reviewer. The GOAL is a clinically accurate, useful answer for the clinician — judge whether the draft ACHIEVES that goal, and if not, say specifically what would. You are guiding toward a good answer, not hunting for reasons to reject one.
+You are a clinical reviewer. You protect the DIRECT ANSWER (strictly) and keep the IN-DEPTH claims honest (claim by claim). The Answer and the In Depth have DIFFERENT scope, so you judge them on different terms — do not hold the In Depth to the Answer's bar.
 
-You receive the patient CHART (the ground truth), the GATHERED CONTEXT the team collected, and a DRAFT ANSWER. The draft has two parts:
-- the **Answer** — the short, direct response to the question;
-- the **In Depth** — an elaboration with extra clinical context.
+You receive: the patient CHART (ground truth), the GATHERED KB / EVIDENCE the team retrieved, the DRAFT ANSWER (the short, direct response), and a NUMBERED list of IN-DEPTH CLAIMS (one per line).
 
-The draft SHOULD cite chart records inline as [N] — that is REQUIRED; never flag it for having citations, and never flag it for "missing an audit". Judge each section's CLINICAL claims against the chart (right value, right date, right interpretation). A citation whose [N] index points to a near-miss record is NOT a failure as long as the clinical value/date is correct — index resolution is checked separately.
+Return JSON only:
+{"answer_ok": <true|false>, "answer_issues": "<the specific fix for the Answer, or empty>", "indepth_drop": [<the NUMBERS of in-depth claims to remove>], "indepth_issues": "<a short note on what you dropped and why, or empty>"}
 
-Judge the two sections SEPARATELY:
-- ANSWER goal — the **Answer** is ACCURATE: its clinical claims are supported by the chart. ("not documented" is accurate when the chart lacks the asked info.)
-- IN DEPTH goal — the **In Depth** is VALID and useful: grounded in the chart — no trend asserted from fewer than two dated points, no time window the data does not cover, no value/date mismatch, no fabricated or mis-cited guidance.
+THE ANSWER — strict (this is the high-stakes part):
+- answer_ok = true when EVERY clinical claim in the Answer is supported by the CHART: right value, right date, right interpretation. "Not documented" is correct (true) when the chart lacks the asked fact.
+- A citation index [N] that resolves to a near-miss record is NOT a failure as long as the clinical value/date is correct — index resolution is checked elsewhere. Never set answer_ok=false merely for HAVING [N] citations (the format requires them).
+- Set answer_ok=false ONLY for a genuine factual or temporal error (wrong number, wrong date, a trend asserted from one point, a value the chart does not contain), and in answer_issues name the exact chart fact that fixes it.
 
-Pass a section that meets its goal. A claim supported by the chart passes — do NOT nitpick wording, do NOT demand completeness beyond the question, do NOT require more than the chart supports. Flag ONLY a genuine clinical or temporal error, and for each, name the exact chart fact that would fix it.
+THE IN-DEPTH CLAIMS — advisory, judged by TYPE (keep useful guidance; drop only what is wrong):
+Read each numbered claim and add its number to indepth_drop ONLY if it fails its own test:
+- A PATIENT claim (a fact about THIS chart) -> must be supported by the chart. Drop it if the value, date, or interpretation is wrong or invented.
+- A GUIDELINE / KB claim (general medical guidance, named in prose like "per WHO HIV guidelines") -> this is EXPECTED to come from OUTSIDE the chart. Do NOT drop it for "not in the chart". Drop it ONLY if it is fabricated (no such guidance, an invented source/title/dose) OR it does not actually apply to this patient's situation.
+- The PURPOSE of the In Depth is to show the retrieved KB correctly INFORMS the answer. Keep a claim that does that. Lean toward KEEPING: drop a claim only when it is clearly wrong, fabricated, mis-applied, or unsupported — never because it could be worded better, never for being incomplete.
+- Do NOT set answer_ok=false because of an In-Depth problem, and do NOT abstain — indepth_drop is how you remediate the In Depth. An empty indepth_drop means keep them all.
 
-Work claim by claim against the chart. Return JSON only:
-{"answer_ok": <true if the Answer is accurate>, "answer_issues": "<the specific fix for the Answer, or empty>", "indepth_ok": <true if the In Depth is valid and useful>, "indepth_issues": "<the specific fix for the In Depth, or empty>"}
+Work claim by claim against the chart and the gathered evidence. Return JSON only.

--- a/server/team.py
+++ b/server/team.py
@@ -342,20 +342,18 @@ def _knob(knobs: Optional[Dict[str, Any]], role: str, key: str, default: Any) ->
 
 
 def _validator_feedback(verdict: Dict[str, Any]) -> str:
-    """Turn a flagged verdict into specific re-synthesis instructions."""
-    parts = ["A reviewer audited your draft against the patient chart and found issues "
-             "that MUST be fixed before the answer is returned:"]
+    """Turn a flagged verdict into goal-oriented re-synthesis guidance."""
+    parts = ["Your goal is an accurate Answer and a valid, useful In Depth, grounded only in "
+             "the patient chart. A reviewer found these gaps to that goal:"]
     ai = (verdict.get("answer_issues") or "").strip()
     ci = (verdict.get("context_issues") or "").strip()
     if ai:
-        parts.append("ANSWER problems: " + ai)
+        parts.append("Answer: " + ai)
     if ci:
-        parts.append("CONTEXT/evidence problems (do not carry these into the answer): " + ci)
+        parts.append("Evidence/context: " + ci)
     parts.append(
-        "Rewrite the answer using ONLY facts supported by the patient chart. Do not assert "
-        "a trend from fewer than two dated points, do not claim a time window the data does "
-        "not cover, keep every date matched to its real value, and answer 'not documented' "
-        "when the chart lacks the information.")
+        "Rewrite to meet the goal: keep what is already accurate, correct the above using only "
+        "chart-supported facts, and where the chart lacks the information say 'not documented'.")
     return "\n".join(parts)
 
 

--- a/server/team.py
+++ b/server/team.py
@@ -33,9 +33,7 @@ import httpx
 
 from . import kb
 from .config import (
-    llm_config, SYNTH_MODEL_HIGH, SYNTH_MODEL_MED, SYNTH_MODEL_LOW,
-    EXPERT_MODEL_HIGH, EXPERT_MODEL_MED, EXPERT_MODEL_LOW,
-    ORCHESTRATOR_MODEL_HIGH, SYNTH_REPEAT_PENALTY,
+    llm_config, SYNTH_REPEAT_PENALTY,
     ORCHESTRATOR_DRY_MULTIPLIER, EXPERT_DRY_MULTIPLIER, SYNTH_DRY_MULTIPLIER,
 )
 from .prompt_loader import load_prompt
@@ -54,41 +52,18 @@ MAX_TOOL_ITERATIONS = 3
 _KB_BLOCK_HEADER = "Knowledge-base reference snippets"
 
 
-# The ONLY models med-agent-hub publishes: three team LEVELS. The OpenAI `model` id
-# selects the level; med-agent-hub applies that level's persistent per-role models +
-# prompts (never sent per request). The orchestrator is e4b for low/med, gemma-4-26b-a4b for high; the synthesizer
-# + clinical-expert models step up low -> med -> high; the `low` level swaps to a
-# synthesis prompt optimized for the smaller synthesizer's model class. Model ids are
-# config-driven (config.py, env-overridable). All three synthesizers are non-gemma-4
-# (Qwen), so none hit the gemma-4 repetition collapse (#622).
-TEAM_PRESETS: Dict[str, Dict[str, str]] = {
-    "med-agent-team-low": {
-        "synthesizer_model": SYNTH_MODEL_LOW,
-        "expert_model": EXPERT_MODEL_LOW,
-        "synthesizer_prompt": "synthesis-low",
-    },
-    "med-agent-team-med": {
-        "synthesizer_model": SYNTH_MODEL_MED,
-        "expert_model": EXPERT_MODEL_MED,
-    },
-    "med-agent-team-high": {
-        "synthesizer_model": SYNTH_MODEL_HIGH,
-        "expert_model": EXPERT_MODEL_HIGH,
-        "orchestrator_model": ORCHESTRATOR_MODEL_HIGH,
-    },
-}
+# Team levels (per-tier orchestrator/expert/synthesizer models + prompts) are
+# declared in server/levels.yaml and resolved by server/levels_loader (see
+# openai_compat._content_for). run_team takes the resolved per-role models, prompt
+# names, and the has_expert toggle as kwargs — no presets baked into code.
 
 
-def team_config_for(model_id: str) -> Dict[str, str]:
-    """Map an advertised team model id to run_team model overrides. Unknown ids
-    (which chartsearchai validation would have rejected) -> defaults (empty)."""
-    return dict(TEAM_PRESETS.get(model_id, {}))
-
-
-def _tool_definitions() -> List[Dict[str, Any]]:
-    """OpenAI tool definitions the orchestrator may call. Descriptions carry the
-    trigger keywords + ordering so a small model sequences kb_search then expert."""
-    return [
+def _tool_definitions(has_expert: bool = True) -> List[Dict[str, Any]]:
+    """OpenAI tool definitions the orchestrator may call. kb_search is always
+    offered; medical_expert only when the level has an expert (so a level with
+    expert: null runs with no expert tool). Descriptions carry the trigger
+    keywords + ordering so a small model sequences kb_search then expert."""
+    tools: List[Dict[str, Any]] = [
         {
             "type": "function",
             "function": {
@@ -146,6 +121,9 @@ def _tool_definitions() -> List[Dict[str, Any]]:
             },
         },
     ]
+    if not has_expert:
+        tools = [t for t in tools if t["function"]["name"] != "medical_expert"]
+    return tools
 
 
 def _chart_context(messages: List[Dict[str, Any]]) -> str:
@@ -338,6 +316,7 @@ async def run_team(
     orchestrator_prompt: Optional[str] = None,
     synthesizer_prompt: Optional[str] = None,
     expert_prompt: Optional[str] = None,
+    has_expert: bool = True,
 ) -> str:
     """
     Run the team for one chartsearchai turn.
@@ -375,7 +354,7 @@ async def run_team(
             for _ in range(MAX_TOOL_ITERATIONS):
                 msg = await _chat(
                     client, model, loop_messages,
-                    tools=_tool_definitions(), temperature=temperature, max_tokens=max_tokens,
+                    tools=_tool_definitions(has_expert), temperature=temperature, max_tokens=max_tokens,
                     dry_multiplier=ORCHESTRATOR_DRY_MULTIPLIER,  # DRY OFF: tool-calling, distortion risk
                 )
                 tool_calls = msg.get("tool_calls")

--- a/server/team.py
+++ b/server/team.py
@@ -199,6 +199,9 @@ async def _run_medical_expert(
     expert_system: str,
     kb_context: str = "",
     model: Optional[str] = None,
+    temperature: float = 0.1,
+    repeat_penalty: Optional[float] = None,
+    dry_multiplier: float = EXPERT_DRY_MULTIPLIER,
 ) -> str:
     """Typed clinical-expert tool: a single MedGemma call, free text (no schema).
     The KB block (when any was retrieved) is placed FIRST in the user message so the
@@ -218,8 +221,8 @@ async def _run_medical_expert(
         {"role": "user", "content": user},
     ]
     try:
-        msg = await _chat(client, model or llm_config.med_model, messages, temperature=0.1,
-                          max_tokens=800, dry_multiplier=EXPERT_DRY_MULTIPLIER)
+        msg = await _chat(client, model or llm_config.med_model, messages, temperature=temperature,
+                          max_tokens=800, repeat_penalty=repeat_penalty, dry_multiplier=dry_multiplier)
         return _message_text(msg) or "(no expert response)"
     except Exception as e:  # tool failure must not abort the turn
         logger.warning("medical_expert tool failed: %s", e)
@@ -323,6 +326,15 @@ _VALIDATOR_RF = {
 }
 
 
+def _knob(knobs: Optional[Dict[str, Any]], role: str, key: str, default: Any) -> Any:
+    """Resolve one per-role sampling knob from a level's `knobs` block, falling back to
+    the global default when the role or key is unset. knobs = {role: {key: value}}."""
+    role_knobs = (knobs or {}).get(role)
+    if isinstance(role_knobs, dict) and role_knobs.get(key) is not None:
+        return role_knobs[key]
+    return default
+
+
 def _validator_feedback(verdict: Dict[str, Any]) -> str:
     """Turn a flagged verdict into specific re-synthesis instructions."""
     parts = ["A reviewer audited your draft against the patient chart and found issues "
@@ -350,6 +362,9 @@ async def _run_validator(
     gathered: str,
     answer: str,
     max_tokens: Optional[int],
+    temperature: float = 0.0,
+    repeat_penalty: Optional[float] = None,
+    dry_multiplier: Optional[float] = None,
 ) -> Dict[str, Any]:
     """One audit pass: judge the gathered CONTEXT and the draft ANSWER separately
     against the chart. Returns {ok, answer_issues, context_issues}; fails OPEN (ok=True)
@@ -368,7 +383,8 @@ async def _run_validator(
     )
     msg = await _chat(
         client, validator_model, [{"role": "user", "content": audit_user}],
-        response_format=_VALIDATOR_RF, temperature=0.0, max_tokens=max_tokens)
+        response_format=_VALIDATOR_RF, temperature=temperature, max_tokens=max_tokens,
+        repeat_penalty=repeat_penalty, dry_multiplier=dry_multiplier)
     try:
         verdict = json.loads(_message_text(msg))
     except (json.JSONDecodeError, TypeError):
@@ -387,7 +403,12 @@ async def _audit_and_revise(
     synth_model: str,
     synth_messages: List[Dict[str, Any]],
     response_format: Optional[Dict[str, Any]],
-    temperature: float,
+    synth_temperature: float,
+    synth_repeat_penalty: Optional[float],
+    synth_dry: Optional[float],
+    validator_temperature: float,
+    validator_repeat_penalty: Optional[float],
+    validator_dry: Optional[float],
     max_tokens: Optional[int],
     max_loops: int,
 ) -> str:
@@ -398,7 +419,9 @@ async def _audit_and_revise(
         try:
             verdict = await _run_validator(
                 client, validator_model, validator_prompt,
-                chart=chart, gathered=gathered, answer=content, max_tokens=max_tokens)
+                chart=chart, gathered=gathered, answer=content, max_tokens=max_tokens,
+                temperature=validator_temperature, repeat_penalty=validator_repeat_penalty,
+                dry_multiplier=validator_dry)
         except Exception as e:
             logger.warning("validator call failed, keeping draft: %s", e)
             return content
@@ -411,9 +434,9 @@ async def _audit_and_revise(
         try:
             msg = await _chat(
                 client, synth_model, revise_messages,
-                response_format=response_format, temperature=temperature,
-                max_tokens=max_tokens, repeat_penalty=SYNTH_REPEAT_PENALTY,
-                dry_multiplier=SYNTH_DRY_MULTIPLIER)
+                response_format=response_format, temperature=synth_temperature,
+                max_tokens=max_tokens, repeat_penalty=synth_repeat_penalty,
+                dry_multiplier=synth_dry)
             revised = _normalize_envelope(_message_text(msg))
             if revised:
                 content = revised
@@ -439,6 +462,7 @@ async def run_team(
     validator_model: Optional[str] = None,
     validator_prompt: Optional[str] = None,
     validator_max_loops: int = 1,
+    knobs: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Run the team for one chartsearchai turn.
@@ -452,6 +476,21 @@ async def run_team(
     synth_model = synthesizer_model or llm_config.synthesizer_model
     expert_model = expert_model or llm_config.med_model
     chart = _chart_context(messages)
+
+    # Per-role sampling knobs: a level may override any role's temperature / repeat_penalty
+    # / dry; unset falls back to today's global default for that role.
+    orch_temp = _knob(knobs, "orchestrator", "temperature", temperature)
+    orch_rp = _knob(knobs, "orchestrator", "repeat_penalty", None)
+    orch_dry = _knob(knobs, "orchestrator", "dry", ORCHESTRATOR_DRY_MULTIPLIER)
+    exp_temp = _knob(knobs, "expert", "temperature", 0.1)
+    exp_rp = _knob(knobs, "expert", "repeat_penalty", None)
+    exp_dry = _knob(knobs, "expert", "dry", EXPERT_DRY_MULTIPLIER)
+    synth_temp = _knob(knobs, "synthesizer", "temperature", max(temperature or 0.0, _SYNTH_MIN_TEMPERATURE))
+    synth_rp = _knob(knobs, "synthesizer", "repeat_penalty", SYNTH_REPEAT_PENALTY)
+    synth_dry = _knob(knobs, "synthesizer", "dry", SYNTH_DRY_MULTIPLIER)
+    val_temp = _knob(knobs, "validator", "temperature", 0.0)
+    val_rp = _knob(knobs, "validator", "repeat_penalty", None)
+    val_dry = _knob(knobs, "validator", "dry", None)
 
     # Read the role prompts ONCE per request; thread the expert text into the
     # per-iteration expert call so the tool loop does not re-read it from disk
@@ -476,8 +515,8 @@ async def run_team(
             for _ in range(MAX_TOOL_ITERATIONS):
                 msg = await _chat(
                     client, model, loop_messages,
-                    tools=_tool_definitions(has_expert), temperature=temperature, max_tokens=max_tokens,
-                    dry_multiplier=ORCHESTRATOR_DRY_MULTIPLIER,  # DRY OFF: tool-calling, distortion risk
+                    tools=_tool_definitions(has_expert), temperature=orch_temp, max_tokens=max_tokens,
+                    repeat_penalty=orch_rp, dry_multiplier=orch_dry,  # DRY default OFF for tool-calling
                 )
                 tool_calls = msg.get("tool_calls")
                 if not tool_calls:
@@ -498,7 +537,8 @@ async def run_team(
                         if name == "medical_expert":
                             observation = await _run_medical_expert(
                                 client, args.get("query", ""), chart, expert_system,
-                                kb_context=kb_context, model=expert_model)
+                                kb_context=kb_context, model=expert_model,
+                                temperature=exp_temp, repeat_penalty=exp_rp, dry_multiplier=exp_dry)
                             expert_notes.append(observation)
                         elif name == "kb_search":
                             observation = _run_kb_search(args.get("query", ""))
@@ -524,12 +564,11 @@ async def run_team(
         synth_user = synthesis_instruction + "\n\n" + gathered if gathered else synthesis_instruction
         synth_messages = list(messages) + [{"role": "user", "content": synth_user}]
         try:
-            synth_temperature = max(temperature or 0.0, _SYNTH_MIN_TEMPERATURE)
             msg = await _chat(
                 client, synth_model, synth_messages,
-                response_format=response_format, temperature=synth_temperature,
-                max_tokens=max_tokens, repeat_penalty=SYNTH_REPEAT_PENALTY,
-                dry_multiplier=SYNTH_DRY_MULTIPLIER,
+                response_format=response_format, temperature=synth_temp,
+                max_tokens=max_tokens, repeat_penalty=synth_rp,
+                dry_multiplier=synth_dry,
             )
             content = _normalize_envelope(_message_text(msg))
             if content:
@@ -539,7 +578,9 @@ async def run_team(
                         validator_model=validator_model, validator_prompt=validator_prompt,
                         chart=chart, gathered=gathered,
                         synth_model=synth_model, synth_messages=synth_messages,
-                        response_format=response_format, temperature=synth_temperature,
+                        response_format=response_format,
+                        synth_temperature=synth_temp, synth_repeat_penalty=synth_rp, synth_dry=synth_dry,
+                        validator_temperature=val_temp, validator_repeat_penalty=val_rp, validator_dry=val_dry,
                         max_tokens=max_tokens, max_loops=validator_max_loops)
                 return content
             logger.warning("synthesis returned empty content; using fallback envelope")

--- a/server/team.py
+++ b/server/team.py
@@ -303,6 +303,125 @@ def _normalize_envelope(raw: str) -> str:
 # is the lever we send. (frequency_penalty here was previously a confirmed no-op.)
 _SYNTH_MIN_TEMPERATURE = 0.5
 
+# The validator returns a structured verdict. The answer and the context are judged
+# as SEPARATE criteria (distinct issue fields) so the feedback localizes where the
+# error entered — bad gathered evidence vs bad synthesis.
+_VALIDATOR_RF = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "validator_verdict",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "ok": {"type": "boolean"},
+                "answer_issues": {"type": "string"},
+                "context_issues": {"type": "string"},
+            },
+            "required": ["ok"],
+        },
+    },
+}
+
+
+def _validator_feedback(verdict: Dict[str, Any]) -> str:
+    """Turn a flagged verdict into specific re-synthesis instructions."""
+    parts = ["A reviewer audited your draft against the patient chart and found issues "
+             "that MUST be fixed before the answer is returned:"]
+    ai = (verdict.get("answer_issues") or "").strip()
+    ci = (verdict.get("context_issues") or "").strip()
+    if ai:
+        parts.append("ANSWER problems: " + ai)
+    if ci:
+        parts.append("CONTEXT/evidence problems (do not carry these into the answer): " + ci)
+    parts.append(
+        "Rewrite the answer using ONLY facts supported by the patient chart. Do not assert "
+        "a trend from fewer than two dated points, do not claim a time window the data does "
+        "not cover, keep every date matched to its real value, and answer 'not documented' "
+        "when the chart lacks the information.")
+    return "\n".join(parts)
+
+
+async def _run_validator(
+    client: httpx.AsyncClient,
+    validator_model: str,
+    validator_prompt: Optional[str],
+    *,
+    chart: str,
+    gathered: str,
+    answer: str,
+    max_tokens: Optional[int],
+) -> Dict[str, Any]:
+    """One audit pass: judge the gathered CONTEXT and the draft ANSWER separately
+    against the chart. Returns {ok, answer_issues, context_issues}; fails OPEN (ok=True)
+    on any malformed verdict so a flaky validator never blocks the run."""
+    instruction = load_prompt(validator_prompt or "validation")
+    try:
+        obj = json.loads(answer)
+        answer_text = obj.get("answer", answer) if isinstance(obj, dict) else answer
+    except (json.JSONDecodeError, TypeError):
+        answer_text = answer
+    audit_user = (
+        instruction
+        + "\n\n=== PATIENT CHART (ground truth) ===\n" + (chart or "(none)")
+        + "\n\n=== GATHERED CONTEXT (evidence the team collected) ===\n" + (gathered or "(none)")
+        + "\n\n=== DRAFT ANSWER (to audit) ===\n" + answer_text
+    )
+    msg = await _chat(
+        client, validator_model, [{"role": "user", "content": audit_user}],
+        response_format=_VALIDATOR_RF, temperature=0.0, max_tokens=max_tokens)
+    try:
+        verdict = json.loads(_message_text(msg))
+    except (json.JSONDecodeError, TypeError):
+        return {"ok": True}
+    return verdict if isinstance(verdict, dict) else {"ok": True}
+
+
+async def _audit_and_revise(
+    client: httpx.AsyncClient,
+    content: str,
+    *,
+    validator_model: str,
+    validator_prompt: Optional[str],
+    chart: str,
+    gathered: str,
+    synth_model: str,
+    synth_messages: List[Dict[str, Any]],
+    response_format: Optional[Dict[str, Any]],
+    temperature: float,
+    max_tokens: Optional[int],
+    max_loops: int,
+) -> str:
+    """Post-synthesis audit round: validate the draft, and on a flag append specific
+    feedback + re-synthesize, up to max_loops cycles. Returns the (possibly revised)
+    envelope. Never raises — any validator/re-synth failure keeps the current draft."""
+    for _ in range(max(0, max_loops)):
+        try:
+            verdict = await _run_validator(
+                client, validator_model, validator_prompt,
+                chart=chart, gathered=gathered, answer=content, max_tokens=max_tokens)
+        except Exception as e:
+            logger.warning("validator call failed, keeping draft: %s", e)
+            return content
+        if verdict.get("ok", True):
+            return content
+        revise_messages = synth_messages + [
+            {"role": "assistant", "content": content},
+            {"role": "user", "content": _validator_feedback(verdict)},
+        ]
+        try:
+            msg = await _chat(
+                client, synth_model, revise_messages,
+                response_format=response_format, temperature=temperature,
+                max_tokens=max_tokens, repeat_penalty=SYNTH_REPEAT_PENALTY,
+                dry_multiplier=SYNTH_DRY_MULTIPLIER)
+            revised = _normalize_envelope(_message_text(msg))
+            if revised:
+                content = revised
+        except Exception as e:
+            logger.warning("re-synthesis after validator flag failed, keeping draft: %s", e)
+            return content
+    return content
+
 
 async def run_team(
     messages: List[Dict[str, Any]],
@@ -317,6 +436,9 @@ async def run_team(
     synthesizer_prompt: Optional[str] = None,
     expert_prompt: Optional[str] = None,
     has_expert: bool = True,
+    validator_model: Optional[str] = None,
+    validator_prompt: Optional[str] = None,
+    validator_max_loops: int = 1,
 ) -> str:
     """
     Run the team for one chartsearchai turn.
@@ -411,6 +533,14 @@ async def run_team(
             )
             content = _normalize_envelope(_message_text(msg))
             if content:
+                if validator_model:
+                    content = await _audit_and_revise(
+                        client, content,
+                        validator_model=validator_model, validator_prompt=validator_prompt,
+                        chart=chart, gathered=gathered,
+                        synth_model=synth_model, synth_messages=synth_messages,
+                        response_format=response_format, temperature=synth_temperature,
+                        max_tokens=max_tokens, max_loops=validator_max_loops)
                 return content
             logger.warning("synthesis returned empty content; using fallback envelope")
         except Exception as e:

--- a/server/team.py
+++ b/server/team.py
@@ -385,11 +385,20 @@ async def _run_validator(
         client, validator_model, [{"role": "user", "content": audit_user}],
         response_format=_VALIDATOR_RF, temperature=temperature, max_tokens=max_tokens,
         repeat_penalty=repeat_penalty, dry_multiplier=dry_multiplier)
+    raw = _message_text(msg)
     try:
-        verdict = json.loads(_message_text(msg))
+        verdict = json.loads(raw)
     except (json.JSONDecodeError, TypeError):
+        logger.warning("validator[%s] verdict UNPARSEABLE -> FAIL-OPEN (pass); chart=%dch gathered=%dch max_tokens=%s raw=%r",
+                       validator_model, len(chart or ""), len(gathered or ""), max_tokens, raw[:240])
         return {"ok": True}
-    return verdict if isinstance(verdict, dict) else {"ok": True}
+    if not isinstance(verdict, dict):
+        logger.warning("validator[%s] verdict not an object -> FAIL-OPEN; raw=%r", validator_model, raw[:240])
+        return {"ok": True}
+    logger.info("validator[%s] ok=%s answer_issues=%r context_issues=%r (chart=%dch gathered=%dch)",
+                validator_model, verdict.get("ok"), (verdict.get("answer_issues") or "")[:200],
+                (verdict.get("context_issues") or "")[:120], len(chart or ""), len(gathered or ""))
+    return verdict
 
 
 async def _audit_and_revise(
@@ -434,6 +443,7 @@ async def _audit_and_revise(
         verdict = await _audit(content)
         if verdict is None or verdict.get("ok", True):
             return content  # clean (or validator unavailable) -> keep draft
+        logger.info("validator flagged the draft -> re-synthesizing with feedback")
         revise_messages = synth_messages + [
             {"role": "assistant", "content": content},
             {"role": "user", "content": _validator_feedback(verdict)},
@@ -452,7 +462,9 @@ async def _audit_and_revise(
             return content  # empty revision -> keep original
         revised_verdict = await _audit(revised)
         if revised_verdict is not None and revised_verdict.get("ok", False):
+            logger.info("validator: revision cleared the flags -> adopted")
             return revised  # revision cleared the flags -> adopt it
+        logger.info("validator: revision still flagged -> kept the original draft")
         return content  # revision still flagged -> keep the original draft
     return content
 

--- a/server/team.py
+++ b/server/team.py
@@ -37,6 +37,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import httpx
 
 from . import kb
+from . import temporal
 from .config import (
     llm_config, SYNTH_REPEAT_PENALTY,
     ORCHESTRATOR_DRY_MULTIPLIER, EXPERT_DRY_MULTIPLIER, SYNTH_DRY_MULTIPLIER,
@@ -832,7 +833,8 @@ def _write_trace(level_id: Optional[str], messages: List[Dict[str, Any]], *, orc
                  expert: str, synthesizer: str, validator: Optional[str],
                  steps: List[Dict[str, Any]], answer_confidence: Dict[str, Any],
                  indepth_confidence: Dict[str, Any], answer_text: str = "",
-                 in_depth_claims: Optional[List[str]] = None) -> None:
+                 in_depth_claims: Optional[List[str]] = None,
+                 reference_date: Optional[str] = None) -> None:
     """Append one per-turn reasoning-trace line — the structured package a client renders (the
     SHIPPED answer + in-depth claims + per-section confidence + the ordered call steps). Best-effort:
     never raises (a trace-write failure must never break a turn)."""
@@ -847,6 +849,7 @@ def _write_trace(level_id: Optional[str], messages: List[Dict[str, Any]], *, orc
             "ts": datetime.now(timezone.utc).isoformat(),
             "level_id": level_id,
             "question": question[:2000],
+            "reference_date": reference_date,
             "models": {"orchestrator": orchestrator, "expert": expert,
                        "synthesizer": synthesizer, "validator": validator},
             "answer_text": answer_text,
@@ -878,6 +881,8 @@ async def run_team(
     validator_model: Optional[str] = None,
     validator_prompt: Optional[str] = None,
     validator_max_loops: int = 1,
+    two_call: bool = True,
+    anchor: Optional[str] = None,
     knobs: Optional[Dict[str, Any]] = None,
     level_id: Optional[str] = None,
 ) -> str:
@@ -893,6 +898,7 @@ async def run_team(
     synth_model = synthesizer_model or llm_config.synthesizer_model
     expert_model = expert_model or llm_config.med_model
     chart = _chart_context(messages)
+    reference_date: Optional[str] = None  # resolved below; recorded in the trace for the judge
 
     # Per-role sampling knobs: a level may override any role's temperature / repeat_penalty
     # / dry; unset falls back to today's global default for that role.
@@ -917,9 +923,15 @@ async def run_team(
     # Two-call synthesis: the level's synthesis_prompt / validator_prompt are BASE names; each
     # role's answer/in-depth prompt is "<base>-answer" / "<base>-indepth" (default base
     # "synthesis" / "validation"). A level can swap the whole set by overriding the base.
+    # Parity (two_call=False): synthesis_prompt is a WHOLE prompt (no -answer/-indepth split) —
+    # one call, no in-depth, validator skipped — so the output is the bare chartsearchai envelope.
     _synth_base = synthesizer_prompt or "synthesis"
-    answer_instruction = load_prompt(_synth_base + "-answer")
-    indepth_instruction = load_prompt(_synth_base + "-indepth")
+    if two_call:
+        answer_instruction = load_prompt(_synth_base + "-answer")
+        indepth_instruction = load_prompt(_synth_base + "-indepth")
+    else:
+        answer_instruction = load_prompt(_synth_base)
+        indepth_instruction = None
 
     # The tool loop runs under the orchestrator's OWN system prompt — not
     # chartsearchai's envelope prompt, which biases a small model toward answering
@@ -1004,30 +1016,70 @@ async def run_team(
         # array (byte-identical for LM Studio's cache); the gathered evidence rides on
         # the last user turn so decisive evidence sits at the end (lost-in-the-middle).
         gathered = _gathered_evidence(kb_context, expert_notes)
-        try:
-            content, synth_steps, answer_conf, indepth_conf, answer_text, claims = \
-                await _synthesize_and_validate(
-                    client,
-                    base_messages=list(messages), gathered=gathered, chart=chart,
-                    synth_model=synth_model,
-                    answer_instruction=answer_instruction, indepth_instruction=indepth_instruction,
-                    response_format=response_format, validator_model=validator_model,
-                    validator_prompt=validator_prompt,
-                    synth_temperature=synth_temp, synth_repeat_penalty=synth_rp, synth_dry=synth_dry,
-                    validator_temperature=val_temp, validator_repeat_penalty=val_rp, validator_dry=val_dry,
-                    max_tokens=max_tokens, max_loops=validator_max_loops)
-            _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
-                         synthesizer=synth_model, validator=validator_model,
-                         steps=orch_steps + synth_steps,
-                         answer_confidence=answer_conf, indepth_confidence=indepth_conf,
-                         answer_text=answer_text, in_depth_claims=claims)
-            return content
-        except Exception as e:
-            logger.error("synthesis failed: %s", e, exc_info=True)
+
+        # Deterministic temporal grounding: resolve the reference "now" (level anchor ->
+        # HUB_ANCHOR env -> latest record date) and prepend the computed series so the synth +
+        # validator REPORT dated facts ("most recent", trend, window) instead of deriving them.
+        anchor_mode = anchor or os.environ.get("HUB_ANCHOR")
+        reference_date = temporal.resolve_anchor(anchor_mode, chart)
+        temporal_block = temporal.build_temporal_block(chart, reference_date)
+        if temporal_block:
+            gathered = temporal_block + ("\n\n" + gathered if gathered else "")
+
+        if not two_call:
+            # Parity lane: ONE chartsearchai-style synthesis call (answer_instruction is the whole
+            # chartsearchai prompt), NO In-Depth, validator skipped -> the bare chartsearchai
+            # {answer, citations, blocks} envelope, so the output format matches the direct
+            # single-LLM arms. Orchestration (kb_search + expert) + the temporal block still feed it.
+            try:
+                p_answer, p_citations, p_blocks = await _synthesize_answer(
+                    client, synth_model, base_messages=list(messages),
+                    answer_instruction=answer_instruction, gathered=gathered,
+                    response_format=response_format, temperature=synth_temp,
+                    max_tokens=max_tokens, repeat_penalty=synth_rp, dry=synth_dry)
+                if p_answer:
+                    _parity_conf = {"level": "green",
+                                    "note": "parity lane: chartsearchai prompt, single call, validator off"}
+                    _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
+                                 synthesizer=synth_model, validator=None,
+                                 steps=orch_steps + [{"role": "synthesizer", "model": synth_model,
+                                                      "mode": "parity-single-call"}],
+                                 answer_confidence=_parity_conf, indepth_confidence=_parity_conf,
+                                 answer_text=p_answer, in_depth_claims=[],
+                                 reference_date=reference_date)
+                    # Bare chartsearchai envelope built directly (NOT _assemble_envelope, which
+                    # forces a "**Answer**" header): no In-Depth, no confidence -> matches direct arms.
+                    return json.dumps({"answer": p_answer,
+                                       "citations": p_citations or [],
+                                       "blocks": p_blocks or []})
+            except Exception as e:
+                logger.error("parity synthesis failed: %s", e, exc_info=True)
+        else:
+            try:
+                content, synth_steps, answer_conf, indepth_conf, answer_text, claims = \
+                    await _synthesize_and_validate(
+                        client,
+                        base_messages=list(messages), gathered=gathered, chart=chart,
+                        synth_model=synth_model,
+                        answer_instruction=answer_instruction, indepth_instruction=indepth_instruction,
+                        response_format=response_format, validator_model=validator_model,
+                        validator_prompt=validator_prompt,
+                        synth_temperature=synth_temp, synth_repeat_penalty=synth_rp, synth_dry=synth_dry,
+                        validator_temperature=val_temp, validator_repeat_penalty=val_rp, validator_dry=val_dry,
+                        max_tokens=max_tokens, max_loops=validator_max_loops)
+                _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
+                             synthesizer=synth_model, validator=validator_model,
+                             steps=orch_steps + synth_steps,
+                             answer_confidence=answer_conf, indepth_confidence=indepth_conf,
+                             answer_text=answer_text, in_depth_claims=claims,
+                             reference_date=reference_date)
+                return content
+            except Exception as e:
+                logger.error("synthesis failed: %s", e, exc_info=True)
 
     _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
                  synthesizer=synth_model, validator=validator_model, steps=orch_steps,
                  answer_confidence={"level": "red", "note": "The team could not produce an answer this turn."},
-                 indepth_confidence={"level": "green", "note": ""})
+                 indepth_confidence={"level": "green", "note": ""}, reference_date=reference_date)
     return _fallback_envelope(
         "I could not produce a complete answer for this turn. Please try again.")

--- a/server/team.py
+++ b/server/team.py
@@ -27,7 +27,7 @@ Design notes (see specs/artifacts/planning/react-team-orchestration-design.md):
 import json
 import logging
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
 
@@ -306,9 +306,10 @@ def _normalize_envelope(raw: str) -> str:
 # is the lever we send. (frequency_penalty here was previously a confirmed no-op.)
 _SYNTH_MIN_TEMPERATURE = 0.5
 
-# The validator returns a structured verdict. The answer and the context are judged
-# as SEPARATE criteria (distinct issue fields) so the feedback localizes where the
-# error entered — bad gathered evidence vs bad synthesis.
+# The validator returns a structured verdict. The Answer and the In Depth are judged on
+# DIFFERENT terms (their scope differs): the Answer is a strict, all-or-nothing chart-accuracy
+# gate; the In Depth is judged claim-by-claim, and the verdict names the specific claim numbers
+# to drop (block/strip). The two drive two INDEPENDENT remediation paths in _audit_and_revise.
 _VALIDATOR_RF = {
     "type": "json_schema",
     "json_schema": {
@@ -318,10 +319,10 @@ _VALIDATOR_RF = {
             "properties": {
                 "answer_ok": {"type": "boolean"},
                 "answer_issues": {"type": "string"},
-                "indepth_ok": {"type": "boolean"},
+                "indepth_drop": {"type": "array", "items": {"type": "integer"}},
                 "indepth_issues": {"type": "string"},
             },
-            "required": ["answer_ok", "indepth_ok"],
+            "required": ["answer_ok", "indepth_drop"],
         },
     },
 }
@@ -333,20 +334,59 @@ _VALIDATOR_ABSTAIN_MSG = (
 )
 
 
-def _drop_indepth(envelope_json: str) -> str:
-    """Granular abstain: keep the **Answer** section, drop a flagged **In Depth** elaboration
-    (ship the grounded direct answer rather than abstaining the whole turn)."""
+_INDEPTH_HEADER_RE = re.compile(r"\*\*\s*in[\s\-]?depth\s*\*\*", re.IGNORECASE)
+_INDEPTH_BULLET_RE = re.compile(r"^\s*(?:[-*•]\s+|\d+[.)]\s+)")
+
+
+def _split_answer_indepth(answer_text: str) -> Tuple[str, List[str]]:
+    """Split a synthesized answer string into (answer_part, indepth_claims). The In Depth is
+    emitted as a markdown bullet list — one claim per bullet — so each claim is individually
+    addressable for claim-level validation. Returns claims=[] when there is no In Depth. If the
+    In-Depth body has no bullets it is treated as ONE claim, so it stays addressable either way."""
+    parts = _INDEPTH_HEADER_RE.split(answer_text or "", maxsplit=1)
+    answer_part = parts[0].rstrip()
+    if len(parts) < 2 or not parts[1].strip():
+        return answer_part, []
+    body = parts[1].strip()
+    lines = [ln for ln in body.splitlines() if ln.strip()]
+    if any(_INDEPTH_BULLET_RE.match(ln) for ln in lines):
+        claims = [_INDEPTH_BULLET_RE.sub("", ln).strip() for ln in lines if _INDEPTH_BULLET_RE.match(ln)]
+    else:
+        claims = [body.strip()]  # not bulleted -> one addressable claim
+    return answer_part, [c for c in claims if c]
+
+
+def _rebuild_answer(answer_part: str, claims: List[str]) -> str:
+    """Reassemble the answer string from the Answer part + the surviving In-Depth claim bullets.
+    With no claim left, ship just the Answer + a brief withheld note — an In-Depth-only miss
+    trims the elaboration, it never blocks the turn (advisory)."""
+    answer_part = answer_part.rstrip()
+    if not claims:
+        return answer_part + (
+            "\n\n_(Supporting detail withheld — it could not be grounded in the chart or the cited guidance.)_")
+    return answer_part + "\n\n**In Depth**\n" + "\n".join("- " + c for c in claims)
+
+
+def _strip_indepth_claims(envelope_json: str, drop: List[int]) -> str:
+    """Block/strip remediation: remove the 1-based In-Depth claim indices in `drop`, keep the
+    rest, leave the **Answer** untouched. Returns the envelope JSON unchanged if there is
+    nothing to drop / it is unparseable / there is no In Depth."""
+    dropset = {d for d in (drop or []) if isinstance(d, int)}
+    if not dropset:
+        return envelope_json
     try:
         env = json.loads(envelope_json)
     except (json.JSONDecodeError, TypeError):
         return envelope_json
-    ans = env.get("answer") or ""
-    parts = re.split(r"\*\*\s*in[\s\-]?depth\s*\*\*", ans, maxsplit=1, flags=re.IGNORECASE)
-    if len(parts) > 1:
-        env["answer"] = parts[0].rstrip() + (
-            "\n\n_(Detailed elaboration withheld — it could not be fully grounded in the chart.)_")
-        return json.dumps(env)
-    return envelope_json  # no In Depth section found -> unchanged
+    ans = env.get("answer")
+    if not isinstance(ans, str):
+        return envelope_json
+    answer_part, claims = _split_answer_indepth(ans)
+    if not claims:
+        return envelope_json
+    kept = [c for i, c in enumerate(claims, start=1) if i not in dropset]
+    env["answer"] = _rebuild_answer(answer_part, kept)
+    return json.dumps(env)
 
 
 def _knob(knobs: Optional[Dict[str, Any]], role: str, key: str, default: Any) -> Any:
@@ -359,18 +399,15 @@ def _knob(knobs: Optional[Dict[str, Any]], role: str, key: str, default: Any) ->
 
 
 def _validator_feedback(verdict: Dict[str, Any]) -> str:
-    """Turn a flagged verdict into goal-oriented re-synthesis guidance."""
-    parts = ["Your goal is an accurate Answer and a valid, useful In Depth, grounded only in "
-             "the patient chart. A reviewer found these gaps to that goal:"]
+    """Answer-focused re-synthesis guidance. The In Depth is remediated separately (claim-level
+    block/strip), so the re-synthesis only needs to fix the direct Answer."""
+    parts = ["Your goal is an accurate direct **Answer**, grounded only in the patient chart."]
     ai = (verdict.get("answer_issues") or "").strip()
-    di = (verdict.get("indepth_issues") or "").strip()
     if ai:
-        parts.append("Answer: " + ai)
-    if di:
-        parts.append("In Depth: " + di)
+        parts.append("A reviewer found this problem with the Answer: " + ai)
     parts.append(
-        "Rewrite to meet the goal: keep what is already accurate, correct the above using only "
-        "chart-supported facts, and where the chart lacks the information say 'not documented'.")
+        "Rewrite the **Answer** to be correct using only chart-supported facts; where the chart "
+        "lacks the information, say 'not documented'. Keep the **In Depth** section as well.")
     return "\n".join(parts)
 
 
@@ -387,20 +424,25 @@ async def _run_validator(
     repeat_penalty: Optional[float] = None,
     dry_multiplier: Optional[float] = None,
 ) -> Dict[str, Any]:
-    """One audit pass: judge the gathered CONTEXT and the draft ANSWER separately
-    against the chart. Returns {ok, answer_issues, context_issues}; fails OPEN (ok=True)
-    on any malformed verdict so a flaky validator never blocks the run."""
+    """One audit pass. The Answer is judged strictly for chart-accuracy; the In Depth is judged
+    claim-by-claim (chart-claims vs the chart; guideline-claims for not-fabricated + attributed +
+    relevantly applied). Returns {answer_ok, answer_issues, indepth_drop:[1-based claim #s to
+    remove], indepth_issues}. Fails OPEN (answer_ok=True, indepth_drop=[]) on any malformed
+    verdict so a flaky validator never blocks the run. `indepth_drop` is clamped to real claim #s."""
     instruction = load_prompt(validator_prompt or "validation")
     try:
         obj = json.loads(answer)
         answer_text = obj.get("answer", answer) if isinstance(obj, dict) else answer
     except (json.JSONDecodeError, TypeError):
         answer_text = answer
+    answer_part, claims = _split_answer_indepth(answer_text)
+    numbered = "\n".join(f"{i}. {c}" for i, c in enumerate(claims, start=1)) or "(no In-Depth claims)"
     audit_user = (
         instruction
         + "\n\n=== PATIENT CHART (ground truth) ===\n" + (chart or "(none)")
-        + "\n\n=== GATHERED CONTEXT (evidence the team collected) ===\n" + (gathered or "(none)")
-        + "\n\n=== DRAFT ANSWER (to audit) ===\n" + answer_text
+        + "\n\n=== GATHERED KB / EVIDENCE (the guidance the team retrieved) ===\n" + (gathered or "(none)")
+        + "\n\n=== DRAFT ANSWER (judge strictly for chart-accuracy) ===\n" + answer_part
+        + "\n\n=== IN-DEPTH CLAIMS (numbered; return the numbers to DROP) ===\n" + numbered
     )
     msg = await _chat(
         client, validator_model, [{"role": "user", "content": audit_user}],
@@ -412,12 +454,14 @@ async def _run_validator(
     except (json.JSONDecodeError, TypeError):
         logger.warning("validator[%s] verdict UNPARSEABLE -> FAIL-OPEN (pass); chart=%dch gathered=%dch raw=%r",
                        validator_model, len(chart or ""), len(gathered or ""), raw[:240])
-        return {"answer_ok": True, "indepth_ok": True}
+        return {"answer_ok": True, "indepth_drop": []}
     if not isinstance(verdict, dict):
         logger.warning("validator[%s] verdict not an object -> FAIL-OPEN; raw=%r", validator_model, raw[:240])
-        return {"answer_ok": True, "indepth_ok": True}
-    logger.info("validator[%s] answer_ok=%s indepth_ok=%s answer_issues=%r indepth_issues=%r (chart=%dch gathered=%dch)",
-                validator_model, verdict.get("answer_ok"), verdict.get("indepth_ok"),
+        return {"answer_ok": True, "indepth_drop": []}
+    drop = [d for d in (verdict.get("indepth_drop") or []) if isinstance(d, int) and 1 <= d <= len(claims)]
+    verdict["indepth_drop"] = drop
+    logger.info("validator[%s] answer_ok=%s drop=%s/%d claims answer_issues=%r indepth_issues=%r (chart=%dch gathered=%dch)",
+                validator_model, verdict.get("answer_ok"), drop, len(claims),
                 (verdict.get("answer_issues") or "")[:160], (verdict.get("indepth_issues") or "")[:120],
                 len(chart or ""), len(gathered or ""))
     return verdict
@@ -443,14 +487,18 @@ async def _audit_and_revise(
     max_tokens: Optional[int],
     max_loops: int,
 ) -> str:
-    """Post-synthesis audit round with GRANULAR, section-aware handling. The validator
-    judges the **Answer** and **In Depth** sections separately:
-      - both clean              -> ship the draft;
-      - Answer ok, In Depth bad -> ship the Answer, DROP the In Depth (don't abstain);
-      - Answer bad              -> re-synthesize; if the Answer is then ok, adopt it
-                                   (dropping the In Depth if still bad); if the Answer is
-                                   still bad, ABSTAIN (never ship a wrong direct answer).
-    Never raises — any validator/re-synth failure keeps the current draft (fail-open)."""
+    """Post-synthesis audit driving TWO INDEPENDENT remediation paths off one verdict — because
+    the Answer and the In Depth have different scope and stakes:
+
+      ANSWER (strict): if the direct Answer is flagged, re-synthesize it (Answer-focused feedback)
+        and re-audit, up to `max_loops`; if it still can't be made chart-accurate, ABSTAIN the turn
+        (never ship a wrong fact).
+      IN DEPTH (advisory, claim-level): block/strip exactly the claims the validator flags; the
+        Answer is never touched and an In-Depth miss never abstains the turn.
+
+    The only coupling is logical: if the Answer abstains there is no elaboration to ship. Never
+    raises — a validator outage fails OPEN (ship the draft); a NEGATIVE Answer verdict that cannot
+    be fixed abstains (we know the Answer is wrong)."""
 
     async def _audit(draft: str) -> Optional[Dict[str, Any]]:
         try:
@@ -463,17 +511,29 @@ async def _audit_and_revise(
             logger.warning("validator call failed: %s", e)
             return None  # fail-open
 
+    def _apply_indepth(draft: str, verdict: Dict[str, Any]) -> str:
+        """IN-DEPTH path: block/strip the flagged claims (Answer untouched)."""
+        drop = verdict.get("indepth_drop") or []
+        if drop:
+            logger.info("validator: In Depth claims %s flagged -> block/strip (Answer untouched)", drop)
+            return _strip_indepth_claims(draft, drop)
+        return draft
+
+    v = await _audit(content)
+    if v is None:
+        return content  # validator unavailable -> fail-open (we have no verdict)
+
+    # ANSWER sound -> ship it, then run the In-Depth path independently.
+    if v.get("answer_ok", True):
+        return _apply_indepth(content, v)
+
+    # ANSWER flagged -> its own remediation path (re-synthesize, re-audit, else abstain).
+    current, cur_verdict = content, v
     for _ in range(max(0, max_loops)):
-        v = await _audit(content)
-        if v is None or (v.get("answer_ok", True) and v.get("indepth_ok", True)):
-            return content  # both sections clean (or validator unavailable)
-        if v.get("answer_ok", True):
-            logger.info("validator: Answer ok, In Depth flagged -> keep Answer, drop In Depth")
-            return _drop_indepth(content)  # granular: ship the grounded Answer, drop the bad elaboration
-        logger.info("validator: Answer flagged -> re-synthesizing with feedback")
+        logger.info("validator: Answer flagged -> re-synthesizing (In Depth handled separately)")
         revise_messages = synth_messages + [
-            {"role": "assistant", "content": content},
-            {"role": "user", "content": _validator_feedback(v)},
+            {"role": "assistant", "content": current},
+            {"role": "user", "content": _validator_feedback(cur_verdict)},
         ]
         try:
             msg = await _chat(
@@ -483,20 +543,17 @@ async def _audit_and_revise(
                 dry_multiplier=synth_dry)
             revised = _normalize_envelope(_message_text(msg))
         except Exception as e:
-            logger.warning("re-synthesis after validator flag failed, keeping draft: %s", e)
-            return content
+            logger.warning("re-synthesis after validator flag failed: %s", e)
+            break  # cannot fix a known-wrong Answer -> abstain
         if not revised:
-            return content  # empty revision -> keep original
+            break
         rv = await _audit(revised)
         if rv is None or rv.get("answer_ok", True):
-            if rv is None or rv.get("indepth_ok", True):
-                logger.info("validator: revision fixed the Answer -> adopted")
-                return revised
-            logger.info("validator: revision fixed the Answer, In Depth still flagged -> adopt + drop In Depth")
-            return _drop_indepth(revised)
-        logger.info("validator: Answer still flagged after re-synth -> ABSTAINING (never ship a wrong answer)")
-        return _fallback_envelope(_VALIDATOR_ABSTAIN_MSG)
-    return content
+            logger.info("validator: revision fixed the Answer -> adopt (then run In-Depth path)")
+            return _apply_indepth(revised, rv or {"indepth_drop": []})
+        current, cur_verdict = revised, rv
+    logger.info("validator: Answer still flagged -> ABSTAINING (never ship a wrong answer)")
+    return _fallback_envelope(_VALIDATOR_ABSTAIN_MSG)
 
 
 async def run_team(

--- a/server/team.py
+++ b/server/team.py
@@ -29,7 +29,9 @@ Design notes (see specs/artifacts/planning/react-team-orchestration-design.md):
 
 import json
 import logging
+import os
 import re
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
@@ -132,6 +134,15 @@ def _tool_definitions(has_expert: bool = True) -> List[Dict[str, Any]]:
 def _chart_context(messages: List[Dict[str, Any]]) -> str:
     """The chart snapshot is chartsearchai's first user message (after system)."""
     for m in messages:
+        if m.get("role") == "user":
+            content = m.get("content")
+            return content if isinstance(content, str) else json.dumps(content)
+    return ""
+
+
+def _latest_user_text(messages: List[Dict[str, Any]]) -> str:
+    """The current turn's question is chartsearchai's LAST user message."""
+    for m in reversed(messages):
         if m.get("role") == "user":
             content = m.get("content")
             return content if isinstance(content, str) else json.dumps(content)
@@ -532,7 +543,7 @@ async def _validate_answer(
     return verdict
 
 
-async def _validate_indepth(
+async def _validate_indepth_verdict(
     client: httpx.AsyncClient,
     validator_model: str,
     *,
@@ -545,9 +556,9 @@ async def _validate_indepth(
     repeat_penalty: Optional[float],
     dry: Optional[float],
     validation_prompt: str = "validation",
-) -> List[int]:
-    """Audit the In-Depth claims claim-by-claim. Returns the 1-based claim numbers to DROP,
-    clamped to 1..len(claims). FAIL-OPEN: returns [] on any parse failure."""
+) -> Dict[str, Any]:
+    """Audit the In-Depth claims claim-by-claim. Returns {drop: [1-based claim numbers, clamped to
+    1..len(claims)], issues: str}. FAIL-OPEN: returns {drop: [], issues: ""} on any parse failure."""
     instruction = load_prompt(validation_prompt + "-indepth")
     numbered = "\n".join(f"{i}. {c}" for i, c in enumerate(claims, start=1))
     audit_user = (
@@ -567,15 +578,63 @@ async def _validate_indepth(
     except (json.JSONDecodeError, TypeError):
         logger.warning("indepth-validator[%s] verdict UNPARSEABLE -> FAIL-OPEN (keep all); raw=%r",
                        validator_model, raw[:240])
-        return []
+        return {"drop": [], "issues": ""}
     if not isinstance(verdict, dict):
         logger.warning("indepth-validator[%s] verdict not an object -> FAIL-OPEN; raw=%r",
                        validator_model, raw[:240])
-        return []
+        return {"drop": [], "issues": ""}
     drop = [d for d in (verdict.get("drop") or []) if isinstance(d, int) and 1 <= d <= len(claims)]
     logger.info("indepth-validator[%s] drop=%s/%d claims issues=%r",
                 validator_model, drop, len(claims), (verdict.get("issues") or "")[:120])
-    return drop
+    return {"drop": drop, "issues": verdict.get("issues", "")}
+
+
+def _nuanced_abstain(verdict: Optional[Dict[str, Any]], answer_text: str) -> str:
+    """Graceful abstain (Answer section). Instead of a blanket refusal, surface what the reviewer
+    found — the answer-validator's `answer_issues` already NAMES the correct chart fact — so the
+    clinician gets the grounded partial + the specific uncertainty. The In-Depth KB context is
+    still shipped separately by the caller."""
+    issue = ((verdict or {}).get("answer_issues") or "").strip()
+    if not issue:
+        return _VALIDATOR_ABSTAIN_MSG
+    return ("I could not confirm a reliable direct answer for this turn. A clinical review of the "
+            "draft found: " + issue + " Please verify against the chart before acting; the context "
+            "below is provided to help.")
+
+
+async def _gen_indepth(
+    client: httpx.AsyncClient, synth_model: str, base_messages: List[Dict[str, Any]],
+    indepth_instruction: str, gathered: str, answer_text: str, *,
+    validator_model: Optional[str], validator_prompt: Optional[str], chart: str,
+    synth_temperature: float, synth_repeat_penalty: Optional[float], synth_dry: Optional[float],
+    validator_temperature: float, validator_repeat_penalty: Optional[float], validator_dry: Optional[float],
+    max_tokens: Optional[int], steps: List[Dict[str, Any]],
+) -> List[str]:
+    """IN-DEPTH path: synthesize the KB-informed claim list, then block/strip the claims the
+    validator flags. Records both calls into `steps`. Returns the surviving claims."""
+    claims = await _synthesize_indepth(
+        client, synth_model, base_messages, indepth_instruction, gathered, answer_text,
+        temperature=synth_temperature, max_tokens=max_tokens,
+        repeat_penalty=synth_repeat_penalty, dry=synth_dry)
+    steps.append({"role": "indepth_synth", "model": synth_model, "claims": list(claims)})
+    if validator_model and claims:
+        try:
+            verdict = await _validate_indepth_verdict(
+                client, validator_model, chart=chart, gathered=gathered,
+                answer_text=answer_text, claims=claims, max_tokens=max_tokens,
+                temperature=validator_temperature, repeat_penalty=validator_repeat_penalty,
+                dry=validator_dry, validation_prompt=validator_prompt or "validation")
+        except Exception as e:
+            logger.warning("indepth-validator call failed: %s", e)
+            verdict = {"drop": [], "issues": ""}
+        drop = verdict.get("drop") or []
+        steps.append({"role": "indepth_validator", "model": validator_model,
+                      "drop": drop, "issues": verdict.get("issues", ""), "claims_in": len(claims)})
+        if drop:
+            logger.info("indepth-validator: claims %s flagged -> block/strip", drop)
+            dropset = set(drop)
+            claims = [c for i, c in enumerate(claims, start=1) if i not in dropset]
+    return claims
 
 
 async def _synthesize_and_validate(
@@ -598,38 +657,54 @@ async def _synthesize_and_validate(
     validator_dry: Optional[float],
     max_tokens: Optional[int],
     max_loops: int,
-) -> str:
+) -> Tuple[str, List[Dict[str, Any]], str]:
     """Two-call generation + two independent validators, combined into one envelope only here.
+    Returns (envelope_json, trace_steps, disposition) — the steps are the per-call reasoning
+    trace, the disposition is full / answer_only / stripped / abstain / synth_failed.
 
       ANSWER (strict): synthesize the direct answer; if the Answer validator flags it WITH a
         reason, re-synthesize (Answer-focused feedback) and re-validate up to `max_loops`. If it
-        still cannot be made chart-accurate, ABSTAIN the turn. A reasonless flag (answer_ok=False
-        with empty answer_issues) is treated as PASS so noise never abstains.
+        still cannot be made chart-accurate, ABSTAIN — but gracefully: a nuanced message (what the
+        review found) PLUS the In-Depth KB context. A reasonless flag (answer_ok=False with empty
+        answer_issues) is treated as PASS so noise never abstains.
       IN DEPTH (advisory, claim-level): synthesize claims from the final answer, then drop exactly
         the claims the In-Depth validator flags. Never abstains the turn.
 
     FAIL-OPEN throughout: a validator outage ships the draft; only a reasoned, unfixable NEGATIVE
     Answer verdict abstains."""
+    steps: List[Dict[str, Any]] = []
+    _idkw = dict(
+        validator_model=validator_model, validator_prompt=validator_prompt, chart=chart,
+        synth_temperature=synth_temperature, synth_repeat_penalty=synth_repeat_penalty, synth_dry=synth_dry,
+        validator_temperature=validator_temperature, validator_repeat_penalty=validator_repeat_penalty,
+        validator_dry=validator_dry, max_tokens=max_tokens, steps=steps)
+
     answer_text, citations, blocks = await _synthesize_answer(
         client, synth_model, base_messages, answer_instruction, gathered,
         response_format=response_format, temperature=synth_temperature,
         max_tokens=max_tokens, repeat_penalty=synth_repeat_penalty, dry=synth_dry)
+    steps.append({"role": "answer_synth", "model": synth_model, "output": answer_text, "citations": citations})
     if not answer_text:
-        return _fallback_envelope(
-            "I could not produce a complete answer for this turn. Please try again.")
+        return (_fallback_envelope(
+            "I could not produce a complete answer for this turn. Please try again."),
+            steps, "synth_failed")
 
     # --- ANSWER path -----------------------------------------------------
     if validator_model:
-        async def _audit(draft: str) -> Optional[Dict[str, Any]]:
+        async def _audit(draft: str, attempt: int) -> Optional[Dict[str, Any]]:
             try:
-                return await _validate_answer(
+                verdict = await _validate_answer(
                     client, validator_model, chart=chart, gathered=gathered, answer_text=draft,
                     max_tokens=max_tokens, temperature=validator_temperature,
                     repeat_penalty=validator_repeat_penalty, dry=validator_dry,
                     validation_prompt=validator_prompt or "validation")
             except Exception as e:
                 logger.warning("answer-validator call failed: %s", e)
-                return None  # fail-open
+                verdict = None  # fail-open
+            steps.append({"role": "answer_validator", "model": validator_model, "attempt": attempt,
+                          "answer_ok": (verdict or {}).get("answer_ok", True),
+                          "answer_issues": (verdict or {}).get("answer_issues", "")})
+            return verdict
 
         def _passed(verdict: Optional[Dict[str, Any]]) -> bool:
             # Pass when: no verdict (fail-open), answer_ok True, OR a reasonless False flag.
@@ -637,10 +712,10 @@ async def _synthesize_and_validate(
                 return True
             return not (verdict.get("answer_issues") or "").strip()
 
-        v = await _audit(answer_text)
+        v = await _audit(answer_text, 0)
         if not _passed(v):
             fixed = False
-            for _ in range(max(0, max_loops)):
+            for i in range(max(0, max_loops)):
                 logger.info("answer-validator: Answer flagged -> re-synthesizing")
                 attempt_text, attempt_cit, attempt_blk = await _synthesize_answer(
                     client, synth_model, base_messages, answer_instruction, gathered,
@@ -651,39 +726,65 @@ async def _synthesize_and_validate(
                          "content": _assemble_envelope(answer_text, citations, blocks, [])},
                         {"role": "user", "content": _answer_feedback(v)},
                     ])
+                steps.append({"role": "answer_resynth", "model": synth_model, "output": attempt_text})
                 if not attempt_text:
                     break  # cannot fix a known-wrong Answer -> abstain
                 answer_text, citations, blocks = attempt_text, attempt_cit, attempt_blk
-                v = await _audit(answer_text)
+                v = await _audit(answer_text, i + 1)
                 if _passed(v):
                     logger.info("answer-validator: revision fixed the Answer -> adopt")
                     fixed = True
                     break
             if not fixed:
-                logger.info("answer-validator: Answer still flagged -> ABSTAINING")
-                return _fallback_envelope(_VALIDATOR_ABSTAIN_MSG)
+                # GRACEFUL ABSTAIN: nuanced Answer (what the review found) + the In-Depth KB context.
+                logger.info("answer-validator: Answer still flagged -> ABSTAINING (graceful)")
+                claims = await _gen_indepth(
+                    client, synth_model, base_messages, indepth_instruction, gathered, answer_text, **_idkw)
+                return (_assemble_envelope(_nuanced_abstain(v, answer_text), [], [], claims),
+                        steps, "abstain")
 
     # --- IN-DEPTH path ---------------------------------------------------
-    claims = await _synthesize_indepth(
-        client, synth_model, base_messages, indepth_instruction, gathered, answer_text,
-        temperature=synth_temperature, max_tokens=max_tokens,
-        repeat_penalty=synth_repeat_penalty, dry=synth_dry)
-    if validator_model and claims:
-        try:
-            drop = await _validate_indepth(
-                client, validator_model, chart=chart, gathered=gathered,
-                answer_text=answer_text, claims=claims, max_tokens=max_tokens,
-                temperature=validator_temperature, repeat_penalty=validator_repeat_penalty,
-                dry=validator_dry, validation_prompt=validator_prompt or "validation")
-        except Exception as e:
-            logger.warning("indepth-validator call failed: %s", e)
-            drop = []  # fail-open
-        if drop:
-            logger.info("indepth-validator: claims %s flagged -> block/strip", drop)
-            dropset = set(drop)
-            claims = [c for i, c in enumerate(claims, start=1) if i not in dropset]
+    claims = await _gen_indepth(
+        client, synth_model, base_messages, indepth_instruction, gathered, answer_text, **_idkw)
+    indepth_step = next((s for s in reversed(steps) if s["role"] == "indepth_validator"), None)
+    disposition = "stripped" if (indepth_step and indepth_step.get("drop")) else ("full" if claims else "answer_only")
+    return _assemble_envelope(answer_text, citations, blocks, claims), steps, disposition
 
-    return _assemble_envelope(answer_text, citations, blocks, claims)
+
+# Per-turn reasoning trace: the hub appends one structured line per turn to a writable mount so the
+# live dashboard can render the full LLM flow (orchestrator -> kb/expert -> answer synth -> answer
+# validator(+resynth) -> in-depth synth -> in-depth validator -> disposition). The dashboard
+# correlates a trace line to a results.jsonl cell by level_id + the ts falling in the cell's
+# started_at..ended_at window (the runner is strictly sequential).
+_TRACE_DIR = os.environ.get("TEAM_TRACE_DIR", "/app/trace")
+
+
+def _write_trace(level_id: Optional[str], messages: List[Dict[str, Any]], *, orchestrator: str,
+                 expert: str, synthesizer: str, validator: Optional[str],
+                 steps: List[Dict[str, Any]], disposition: str) -> None:
+    """Append one per-turn reasoning-trace line. Best-effort: never raises (a trace-write failure
+    must never break a turn)."""
+    try:
+        question = ""
+        for m in reversed(messages):
+            if m.get("role") == "user":
+                c = m.get("content")
+                question = c if isinstance(c, str) else json.dumps(c)
+                break
+        entry = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "level_id": level_id,
+            "question": question[:2000],
+            "models": {"orchestrator": orchestrator, "expert": expert,
+                       "synthesizer": synthesizer, "validator": validator},
+            "disposition": disposition,
+            "steps": steps,
+        }
+        os.makedirs(_TRACE_DIR, exist_ok=True)
+        with open(os.path.join(_TRACE_DIR, "trace.jsonl"), "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, default=str) + "\n")
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("trace write failed (non-fatal): %s", e)
 
 
 async def run_team(
@@ -703,6 +804,7 @@ async def run_team(
     validator_prompt: Optional[str] = None,
     validator_max_loops: int = 1,
     knobs: Optional[Dict[str, Any]] = None,
+    level_id: Optional[str] = None,
 ) -> str:
     """
     Run the team for one chartsearchai turn.
@@ -753,6 +855,7 @@ async def run_team(
 
     kb_context = ""          # accumulated KB snippets, threaded into the expert + synthesis
     expert_notes: List[str] = []  # accumulated clinical-expert observations
+    orch_steps: List[Dict[str, Any]] = []  # reasoning-trace steps for the orchestrator tool loop
 
     async with httpx.AsyncClient() as client:
         # --- tool loop (plain: tools, no response_format) -------------------
@@ -764,6 +867,8 @@ async def run_team(
                     repeat_penalty=orch_rp, dry_multiplier=orch_dry,  # DRY default OFF for tool-calling
                 )
                 tool_calls = msg.get("tool_calls")
+                orch_steps.append({"role": "orchestrator", "model": model,
+                                   "tool_calls": [tc.get("function", {}).get("name") for tc in (tool_calls or [])]})
                 if not tool_calls:
                     break  # orchestrator has gathered enough; proceed to synthesis
                 loop_messages.append(msg)
@@ -785,12 +890,17 @@ async def run_team(
                                 kb_context=kb_context, model=expert_model,
                                 temperature=exp_temp, repeat_penalty=exp_rp, dry_multiplier=exp_dry)
                             expert_notes.append(observation)
+                            orch_steps.append({"role": "medical_expert", "model": expert_model,
+                                               "query": args.get("query", ""), "note": observation[:400]})
                         elif name == "kb_search":
                             observation = _run_kb_search(args.get("query", ""))
-                            if observation.startswith(_KB_BLOCK_HEADER):
+                            hit = observation.startswith(_KB_BLOCK_HEADER)
+                            if hit:
                                 kb_context = (
                                     kb_context + "\n\n" + observation if kb_context else observation
                                 )
+                            orch_steps.append({"role": "kb_search", "query": args.get("query", ""),
+                                               "hit": hit, "chars": len(observation)})
                         else:
                             observation = f"(unknown tool: {name})"
                     loop_messages.append({
@@ -801,13 +911,26 @@ async def run_team(
         except Exception as e:
             logger.warning("orchestrator tool loop failed, proceeding to synthesis: %s", e)
 
+        # KB-retrieval fallback: small orchestrators often skip kb_search (esp. on follow-up
+        # turns), leaving the In-Depth with no guidance to ground. If nothing was gathered, do one
+        # deterministic kb_search on the question so the synthesis still has reference context.
+        if not kb_context:
+            q = _latest_user_text(messages)
+            if q:
+                obs = _run_kb_search(q)
+                hit = obs.startswith(_KB_BLOCK_HEADER)
+                if hit:
+                    kb_context = obs
+                orch_steps.append({"role": "kb_search", "query": q[:160], "hit": hit,
+                                   "chars": len(obs), "fallback": True})
+
         # --- generation: two distinct calls (answer + in-depth), each validated,
         # combined into one envelope. The base prefix is the ORIGINAL chartsearchai
         # array (byte-identical for LM Studio's cache); the gathered evidence rides on
         # the last user turn so decisive evidence sits at the end (lost-in-the-middle).
         gathered = _gathered_evidence(kb_context, expert_notes)
         try:
-            content = await _synthesize_and_validate(
+            content, synth_steps, disposition = await _synthesize_and_validate(
                 client,
                 base_messages=list(messages), gathered=gathered, chart=chart,
                 synth_model=synth_model,
@@ -817,9 +940,15 @@ async def run_team(
                 synth_temperature=synth_temp, synth_repeat_penalty=synth_rp, synth_dry=synth_dry,
                 validator_temperature=val_temp, validator_repeat_penalty=val_rp, validator_dry=val_dry,
                 max_tokens=max_tokens, max_loops=validator_max_loops)
+            _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
+                         synthesizer=synth_model, validator=validator_model,
+                         steps=orch_steps + synth_steps, disposition=disposition)
             return content
         except Exception as e:
             logger.error("synthesis failed: %s", e, exc_info=True)
 
+    _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
+                 synthesizer=synth_model, validator=validator_model,
+                 steps=orch_steps, disposition="synth_failed")
     return _fallback_envelope(
         "I could not produce a complete answer for this turn. Please try again.")

--- a/server/team.py
+++ b/server/team.py
@@ -27,6 +27,7 @@ Design notes (see specs/artifacts/planning/react-team-orchestration-design.md):
   the turn still synthesizes; a hard failure returns a minimal fallback envelope.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -150,6 +151,18 @@ def _latest_user_text(messages: List[Dict[str, Any]]) -> str:
     return ""
 
 
+# Serialize ALL calls to the LLM backend hub-wide. The llama.cpp router (build 9430) has an
+# unfixed TOCTOU race in models-max eviction (ggml-org/llama.cpp#20137, closed "not planned"):
+# concurrent requests bypass the load gate, so a request can land on a model the router is
+# evicting -> it force-kills that child after DEFAULT_STOP_TIMEOUT (hardcoded 10s) -> the call
+# fails with "Failed to read connection" (also #18063 on stream:false). The issue's own
+# recommendation is to QUEUE requests instead of letting them bypass; since the router won't,
+# we serialize client-side: exactly one model request in flight at a time, so the router only
+# ever loads/evicts ONE model with no concurrent request to race -> clean sequential loading
+# (the single-GPU host serves one model at a time regardless, so this costs no real throughput).
+_ROUTER_LOCK = asyncio.Lock()
+
+
 async def _chat(
     client: httpx.AsyncClient,
     model: str,
@@ -187,11 +200,15 @@ async def _chat(
     url = f"{llm_config.base_url.rstrip('/')}/v1/chat/completions"
     logger.info("team _chat: model=%s tools=%s response_format=%s",
                 model, bool(tools), bool(response_format))
-    resp = await client.post(url, json=payload, headers=headers, timeout=180.0)
+    # Hold the lock for the WHOLE request (load + generate) so the router never sees a second
+    # request while it is loading/evicting a model. Timeout covers a cold big-model load + a long
+    # thinking generation. The lock makes loads strictly sequential — no eviction-vs-serve race.
+    async with _ROUTER_LOCK:
+        resp = await client.post(url, json=payload, headers=headers, timeout=600.0)
     if resp.status_code >= 400:
-        # Surface LM Studio's reason (context overflow, bad schema, etc.) — bare
+        # Surface the backend's reason (context overflow, bad schema, model-load failure) — bare
         # status codes are not actionable.
-        logger.error("LM Studio %s for model=%s tools=%s response_format=%s: %s",
+        logger.error("router %s for model=%s tools=%s response_format=%s: %s",
                      resp.status_code, model, bool(tools), bool(response_format),
                      resp.text[:800])
         resp.raise_for_status()

--- a/server/team.py
+++ b/server/team.py
@@ -372,12 +372,6 @@ _INDEPTH_VERDICT_RF = {
 }
 
 
-_VALIDATOR_ABSTAIN_MSG = (
-    "I could not produce a reliably grounded answer for this turn — the available chart "
-    "data does not clearly support a confident response. Please review the chart directly."
-)
-
-
 def _knob(knobs: Optional[Dict[str, Any]], role: str, key: str, default: Any) -> Any:
     """Resolve one per-role sampling knob from a level's `knobs` block, falling back to
     the global default when the role or key is unset. knobs = {role: {key: value}}."""
@@ -387,25 +381,51 @@ def _knob(knobs: Optional[Dict[str, Any]], role: str, key: str, default: Any) ->
     return default
 
 
-def _answer_body(answer_text: str, claims: List[str]) -> str:
-    """Combine the direct Answer and the In-Depth claims into one markdown body. The Answer
-    leads under a **Answer** header; non-empty claims follow as a **In Depth** bullet list."""
-    body = "**Answer**\n" + (answer_text or "").strip()
+_CONF_ICON = {"green": "🟢", "yellow": "🟡", "red": "🔴"}
+
+
+def _caveat(conf: Optional[Dict[str, Any]]) -> str:
+    """A one-line clinician-facing confidence caveat for a section (empty for green / no note)."""
+    if not conf:
+        return ""
+    level = conf.get("level")
+    note = (conf.get("note") or "").strip()
+    if level in (None, "green") or not note:
+        return ""
+    return "\n\n> " + _CONF_ICON.get(level, "") + " " + note
+
+
+def _answer_body(answer_text: str, claims: List[str],
+                 answer_conf: Optional[Dict[str, Any]] = None,
+                 indepth_conf: Optional[Dict[str, Any]] = None) -> str:
+    """Combine the direct Answer and the In-Depth claims into one markdown body, each followed by
+    its confidence caveat (a 🟡/🔴 note; green adds nothing). The Answer leads under a **Answer**
+    header; non-empty claims follow as a **In Depth** bullet list."""
+    body = "**Answer**\n" + (answer_text or "").strip() + _caveat(answer_conf)
     if claims:
-        body += "\n\n**In Depth**\n" + "\n".join("- " + c for c in claims)
+        body += "\n\n**In Depth**\n" + "\n".join("- " + c for c in claims) + _caveat(indepth_conf)
+    elif _caveat(indepth_conf):  # red In-Depth with no surviving claims still carries its note
+        body += "\n\n**In Depth**" + _caveat(indepth_conf)
     return body
 
 
 def _assemble_envelope(
-    answer_text: str, citations: List[int], blocks: List[Any], claims: List[str]
+    answer_text: str, citations: List[int], blocks: List[Any], claims: List[str],
+    answer_conf: Optional[Dict[str, Any]] = None, indepth_conf: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Serialize the chartsearchai {answer, citations, blocks} envelope, where `answer` is the
-    combined Answer + In-Depth markdown body."""
-    return json.dumps({
-        "answer": _answer_body(answer_text, claims),
+    combined Answer + In-Depth markdown body. Also carries a forward-looking `confidence` block
+    (per-section {level, note}) — chartsearchai drops it today; the harness reads confidence from
+    the reasoning trace, and the markdown caveats render everywhere meanwhile."""
+    env: Dict[str, Any] = {
+        "answer": _answer_body(answer_text, claims, answer_conf, indepth_conf),
         "citations": citations or [],
         "blocks": blocks or [],
-    })
+    }
+    if answer_conf or indepth_conf:
+        env["confidence"] = {"answer": answer_conf or {"level": "green", "note": ""},
+                             "in_depth": indepth_conf or {"level": "green", "note": ""}}
+    return json.dumps(env)
 
 
 def _answer_fields(normalized_json_str: str) -> Tuple[str, List[int], List[Any]]:
@@ -478,15 +498,17 @@ async def _synthesize_indepth(
     max_tokens: Optional[int],
     repeat_penalty: Optional[float],
     dry: Optional[float],
+    extra_msgs: Optional[List[Dict[str, Any]]] = None,
 ) -> List[str]:
     """In-Depth synthesis: elaborate the already-produced direct answer into a list of claim
-    strings (one addressable claim each). FAIL-OPEN: returns [] on any error."""
+    strings (one addressable claim each). `extra_msgs` carries the prior draft + validator
+    feedback on a re-synthesis pass. FAIL-OPEN: returns [] on any error."""
     user = (
         indepth_instruction
         + "\n\n=== DIRECT ANSWER (elaborate THIS; do not restate it) ===\n" + answer_text
         + ("\n\n=== GATHERED KB / EVIDENCE ===\n" + gathered if gathered else "")
     )
-    messages = list(base_messages) + [{"role": "user", "content": user}]
+    messages = list(base_messages) + [{"role": "user", "content": user}] + (extra_msgs or [])
     try:
         msg = await _chat(
             client, synth_model, messages,
@@ -589,17 +611,45 @@ async def _validate_indepth_verdict(
     return {"drop": drop, "issues": verdict.get("issues", "")}
 
 
-def _nuanced_abstain(verdict: Optional[Dict[str, Any]], answer_text: str) -> str:
-    """Graceful abstain (Answer section). Instead of a blanket refusal, surface what the reviewer
-    found — the answer-validator's `answer_issues` already NAMES the correct chart fact — so the
-    clinician gets the grounded partial + the specific uncertainty. The In-Depth KB context is
-    still shipped separately by the caller."""
-    issue = ((verdict or {}).get("answer_issues") or "").strip()
-    if not issue:
-        return _VALIDATOR_ABSTAIN_MSG
-    return ("I could not confirm a reliable direct answer for this turn. A clinical review of the "
-            "draft found: " + issue + " Please verify against the chart before acting; the context "
-            "below is provided to help.")
+def _answer_note(level: str, first_issue: str, last_issue: str) -> str:
+    """Clinician-facing confidence note for the Answer, composed deterministically from the
+    validator verdicts captured during the re-synth cycle (no extra LLM call)."""
+    if level == "yellow":
+        base = "An initial draft was flagged on clinical review and corrected on a second pass"
+        return base + ((" (first issue: " + first_issue + ")") if first_issue else "") + "."
+    if level == "red":
+        return ("Low confidence — clinical review still flagged this after a revision: "
+                + (last_issue or first_issue or "the answer could not be confirmed against the chart.")
+                + " Verify against the chart before acting.")
+    return ""
+
+
+def _indepth_note(level: str, n_dropped: int, issues: str) -> str:
+    """Clinician-facing confidence note for the In-Depth, from the validator verdict."""
+    if level == "yellow":
+        return "Supporting context was flagged on review and regenerated."
+    if level == "red":
+        base = "Some supporting context could not be reliably grounded"
+        if n_dropped:
+            base += " (" + str(n_dropped) + " point(s) removed)"
+        return base + ((": " + issues) if issues else "") + "."
+    return ""
+
+
+def _indepth_feedback(verdict: Dict[str, Any], claims: List[str]) -> str:
+    """In-Depth re-synthesis guidance from the validator verdict (the flagged claims + the note)."""
+    issues = (verdict.get("issues") or "").strip()
+    drop = verdict.get("drop") or []
+    flagged = "; ".join(claims[i - 1] for i in drop if 1 <= i <= len(claims))
+    parts = ["Some In-Depth points were flagged on clinical review."]
+    if flagged:
+        parts.append("Flagged points: " + flagged)
+    if issues:
+        parts.append("Reviewer note: " + issues)
+    parts.append("Rewrite the In-Depth as a fresh list of claims: drop or correct the flagged points, "
+                 "keep only well-grounded WHO/guideline guidance applied to this patient, and never "
+                 "invent a source, dose, or value.")
+    return "\n".join(parts)
 
 
 async def _gen_indepth(
@@ -608,33 +658,64 @@ async def _gen_indepth(
     validator_model: Optional[str], validator_prompt: Optional[str], chart: str,
     synth_temperature: float, synth_repeat_penalty: Optional[float], synth_dry: Optional[float],
     validator_temperature: float, validator_repeat_penalty: Optional[float], validator_dry: Optional[float],
-    max_tokens: Optional[int], steps: List[Dict[str, Any]],
-) -> List[str]:
-    """IN-DEPTH path: synthesize the KB-informed claim list, then block/strip the claims the
-    validator flags. Records both calls into `steps`. Returns the surviving claims."""
-    claims = await _synthesize_indepth(
-        client, synth_model, base_messages, indepth_instruction, gathered, answer_text,
-        temperature=synth_temperature, max_tokens=max_tokens,
-        repeat_penalty=synth_repeat_penalty, dry=synth_dry)
-    steps.append({"role": "indepth_synth", "model": synth_model, "claims": list(claims)})
-    if validator_model and claims:
+    max_tokens: Optional[int], max_loops: int, steps: List[Dict[str, Any]],
+) -> Tuple[List[str], Dict[str, Any]]:
+    """IN-DEPTH path with the same confidence cycle as the Answer: synthesize the KB-informed claim
+    list, audit it; if flagged, RE-SYNTHESIZE (with feedback) and re-audit BEFORE stripping. Returns
+    (surviving_claims, confidence) where confidence.level is green (clean first pass) / yellow
+    (flagged then cleared on re-synth) / red (still flagged -> the survivors are kept, the rest
+    block/stripped). Records every call into `steps`."""
+    green = {"level": "green", "note": ""}
+
+    async def _audit(cl: List[str], attempt: int) -> Dict[str, Any]:
         try:
             verdict = await _validate_indepth_verdict(
                 client, validator_model, chart=chart, gathered=gathered,
-                answer_text=answer_text, claims=claims, max_tokens=max_tokens,
+                answer_text=answer_text, claims=cl, max_tokens=max_tokens,
                 temperature=validator_temperature, repeat_penalty=validator_repeat_penalty,
                 dry=validator_dry, validation_prompt=validator_prompt or "validation")
         except Exception as e:
             logger.warning("indepth-validator call failed: %s", e)
             verdict = {"drop": [], "issues": ""}
-        drop = verdict.get("drop") or []
-        steps.append({"role": "indepth_validator", "model": validator_model,
-                      "drop": drop, "issues": verdict.get("issues", ""), "claims_in": len(claims)})
-        if drop:
-            logger.info("indepth-validator: claims %s flagged -> block/strip", drop)
-            dropset = set(drop)
-            claims = [c for i, c in enumerate(claims, start=1) if i not in dropset]
-    return claims
+        steps.append({"role": "indepth_validator", "model": validator_model, "attempt": attempt,
+                      "drop": verdict.get("drop") or [], "issues": verdict.get("issues", ""),
+                      "claims_in": len(cl)})
+        return verdict
+
+    claims = await _synthesize_indepth(
+        client, synth_model, base_messages, indepth_instruction, gathered, answer_text,
+        temperature=synth_temperature, max_tokens=max_tokens,
+        repeat_penalty=synth_repeat_penalty, dry=synth_dry)
+    steps.append({"role": "indepth_synth", "model": synth_model, "claims": list(claims)})
+    if not (validator_model and claims):
+        return claims, green
+
+    v = await _audit(claims, 0)
+    if not (v.get("drop") or []):
+        return claims, green
+
+    # flagged -> re-synthesize the In-Depth (feedback) and re-audit BEFORE stripping.
+    for _ in range(max(0, max_loops)):
+        logger.info("indepth-validator: claims flagged -> re-synthesizing")
+        revised = await _synthesize_indepth(
+            client, synth_model, base_messages, indepth_instruction, gathered, answer_text,
+            temperature=synth_temperature, max_tokens=max_tokens,
+            repeat_penalty=synth_repeat_penalty, dry=synth_dry,
+            extra_msgs=[{"role": "assistant", "content": json.dumps({"claims": claims})},
+                        {"role": "user", "content": _indepth_feedback(v, claims)}])
+        steps.append({"role": "indepth_resynth", "model": synth_model, "claims": list(revised)})
+        if not revised:
+            break
+        claims = revised
+        v = await _audit(claims, 1)
+        if not (v.get("drop") or []):
+            return claims, {"level": "yellow", "note": _indepth_note("yellow", 0, "")}
+
+    # still flagged after re-synth -> block/strip the remaining flagged claims (red).
+    drop = v.get("drop") or []
+    kept = [c for i, c in enumerate(claims, start=1) if i not in set(drop)]
+    logger.info("indepth-validator: still flagged after re-synth -> strip %s", drop)
+    return kept, {"level": "red", "note": _indepth_note("red", len(drop), v.get("issues", ""))}
 
 
 async def _synthesize_and_validate(
@@ -657,27 +738,26 @@ async def _synthesize_and_validate(
     validator_dry: Optional[float],
     max_tokens: Optional[int],
     max_loops: int,
-) -> Tuple[str, List[Dict[str, Any]], str]:
+) -> Tuple[str, List[Dict[str, Any]], Dict[str, Any], Dict[str, Any], str, List[str]]:
     """Two-call generation + two independent validators, combined into one envelope only here.
-    Returns (envelope_json, trace_steps, disposition) — the steps are the per-call reasoning
-    trace, the disposition is full / answer_only / stripped / abstain / synth_failed.
-
-      ANSWER (strict): synthesize the direct answer; if the Answer validator flags it WITH a
-        reason, re-synthesize (Answer-focused feedback) and re-validate up to `max_loops`. If it
-        still cannot be made chart-accurate, ABSTAIN — but gracefully: a nuanced message (what the
-        review found) PLUS the In-Depth KB context. A reasonless flag (answer_ok=False with empty
-        answer_issues) is treated as PASS so noise never abstains.
-      IN DEPTH (advisory, claim-level): synthesize claims from the final answer, then drop exactly
-        the claims the In-Depth validator flags. Never abstains the turn.
-
-    FAIL-OPEN throughout: a validator outage ships the draft; only a reasoned, unfixable NEGATIVE
-    Answer verdict abstains."""
+    Returns (envelope_json, trace_steps, answer_confidence, indepth_confidence, answer_text,
+    in_depth_claims) — the last two are the SHIPPED content (clean), so the trace package can carry
+    the structured pieces a client renders. Each confidence is
+    {level: green|yellow|red, note: <clinician caveat>} from that section's re-synth cycle:
+      green  = passed clinical review on the first pass;
+      yellow = flagged, re-synthesized, then cleared;
+      red    = flagged, re-synthesized, still flagged.
+    We ALWAYS present the answer — a red section ships with its criticism (no abstain); the renderer
+    collapses a red Answer by default. A reasonless Answer flag (answer_ok=False, empty
+    answer_issues) is treated as PASS so noise never lowers confidence. FAIL-OPEN: a validator
+    outage ships the draft at green."""
     steps: List[Dict[str, Any]] = []
     _idkw = dict(
         validator_model=validator_model, validator_prompt=validator_prompt, chart=chart,
         synth_temperature=synth_temperature, synth_repeat_penalty=synth_repeat_penalty, synth_dry=synth_dry,
         validator_temperature=validator_temperature, validator_repeat_penalty=validator_repeat_penalty,
-        validator_dry=validator_dry, max_tokens=max_tokens, steps=steps)
+        validator_dry=validator_dry, max_tokens=max_tokens, max_loops=max_loops, steps=steps)
+    green = {"level": "green", "note": ""}
 
     answer_text, citations, blocks = await _synthesize_answer(
         client, synth_model, base_messages, answer_instruction, gathered,
@@ -685,11 +765,13 @@ async def _synthesize_and_validate(
         max_tokens=max_tokens, repeat_penalty=synth_repeat_penalty, dry=synth_dry)
     steps.append({"role": "answer_synth", "model": synth_model, "output": answer_text, "citations": citations})
     if not answer_text:
+        conf = {"level": "red", "note": "The team could not produce an answer this turn."}
         return (_fallback_envelope(
             "I could not produce a complete answer for this turn. Please try again."),
-            steps, "synth_failed")
+            steps, conf, dict(green), "", [])
 
-    # --- ANSWER path -----------------------------------------------------
+    # --- ANSWER path (confidence: green clean / yellow fixed-on-retry / red still-flagged) ---
+    answer_conf = dict(green)
     if validator_model:
         async def _audit(draft: str, attempt: int) -> Optional[Dict[str, Any]]:
             try:
@@ -714,6 +796,7 @@ async def _synthesize_and_validate(
 
         v = await _audit(answer_text, 0)
         if not _passed(v):
+            first_issue = (v.get("answer_issues") or "").strip()
             fixed = False
             for i in range(max(0, max_loops)):
                 logger.info("answer-validator: Answer flagged -> re-synthesizing")
@@ -728,32 +811,31 @@ async def _synthesize_and_validate(
                     ])
                 steps.append({"role": "answer_resynth", "model": synth_model, "output": attempt_text})
                 if not attempt_text:
-                    break  # cannot fix a known-wrong Answer -> abstain
+                    break  # re-synth produced nothing; keep the last answer, mark red
                 answer_text, citations, blocks = attempt_text, attempt_cit, attempt_blk
                 v = await _audit(answer_text, i + 1)
                 if _passed(v):
-                    logger.info("answer-validator: revision fixed the Answer -> adopt")
+                    logger.info("answer-validator: revision fixed the Answer -> yellow")
                     fixed = True
                     break
-            if not fixed:
-                # GRACEFUL ABSTAIN: nuanced Answer (what the review found) + the In-Depth KB context.
-                logger.info("answer-validator: Answer still flagged -> ABSTAINING (graceful)")
-                claims = await _gen_indepth(
-                    client, synth_model, base_messages, indepth_instruction, gathered, answer_text, **_idkw)
-                return (_assemble_envelope(_nuanced_abstain(v, answer_text), [], [], claims),
-                        steps, "abstain")
+            if fixed:
+                answer_conf = {"level": "yellow", "note": _answer_note("yellow", first_issue, "")}
+            else:
+                # RED: keep the (last) flagged answer + its criticism — never hide it (renderer collapses).
+                last_issue = (v.get("answer_issues") or "").strip()
+                logger.info("answer-validator: Answer still flagged -> red (present + caveat)")
+                answer_conf = {"level": "red", "note": _answer_note("red", first_issue, last_issue)}
 
-    # --- IN-DEPTH path ---------------------------------------------------
-    claims = await _gen_indepth(
+    # --- IN-DEPTH path (same green/yellow/red cycle) ---------------------
+    claims, indepth_conf = await _gen_indepth(
         client, synth_model, base_messages, indepth_instruction, gathered, answer_text, **_idkw)
-    indepth_step = next((s for s in reversed(steps) if s["role"] == "indepth_validator"), None)
-    disposition = "stripped" if (indepth_step and indepth_step.get("drop")) else ("full" if claims else "answer_only")
-    return _assemble_envelope(answer_text, citations, blocks, claims), steps, disposition
+    return (_assemble_envelope(answer_text, citations, blocks, claims, answer_conf, indepth_conf),
+            steps, answer_conf, indepth_conf, answer_text, claims)
 
 
 # Per-turn reasoning trace: the hub appends one structured line per turn to a writable mount so the
 # live dashboard can render the full LLM flow (orchestrator -> kb/expert -> answer synth -> answer
-# validator(+resynth) -> in-depth synth -> in-depth validator -> disposition). The dashboard
+# validator(+resynth) -> in-depth synth -> in-depth validator) + per-section confidence. The dashboard
 # correlates a trace line to a results.jsonl cell by level_id + the ts falling in the cell's
 # started_at..ended_at window (the runner is strictly sequential).
 _TRACE_DIR = os.environ.get("TEAM_TRACE_DIR", "/app/trace")
@@ -761,9 +843,12 @@ _TRACE_DIR = os.environ.get("TEAM_TRACE_DIR", "/app/trace")
 
 def _write_trace(level_id: Optional[str], messages: List[Dict[str, Any]], *, orchestrator: str,
                  expert: str, synthesizer: str, validator: Optional[str],
-                 steps: List[Dict[str, Any]], disposition: str) -> None:
-    """Append one per-turn reasoning-trace line. Best-effort: never raises (a trace-write failure
-    must never break a turn)."""
+                 steps: List[Dict[str, Any]], answer_confidence: Dict[str, Any],
+                 indepth_confidence: Dict[str, Any], answer_text: str = "",
+                 in_depth_claims: Optional[List[str]] = None) -> None:
+    """Append one per-turn reasoning-trace line — the structured package a client renders (the
+    SHIPPED answer + in-depth claims + per-section confidence + the ordered call steps). Best-effort:
+    never raises (a trace-write failure must never break a turn)."""
     try:
         question = ""
         for m in reversed(messages):
@@ -777,7 +862,10 @@ def _write_trace(level_id: Optional[str], messages: List[Dict[str, Any]], *, orc
             "question": question[:2000],
             "models": {"orchestrator": orchestrator, "expert": expert,
                        "synthesizer": synthesizer, "validator": validator},
-            "disposition": disposition,
+            "answer_text": answer_text,
+            "in_depth_claims": in_depth_claims or [],
+            "answer_confidence": answer_confidence,
+            "indepth_confidence": indepth_confidence,
             "steps": steps,
         }
         os.makedirs(_TRACE_DIR, exist_ok=True)
@@ -930,25 +1018,29 @@ async def run_team(
         # the last user turn so decisive evidence sits at the end (lost-in-the-middle).
         gathered = _gathered_evidence(kb_context, expert_notes)
         try:
-            content, synth_steps, disposition = await _synthesize_and_validate(
-                client,
-                base_messages=list(messages), gathered=gathered, chart=chart,
-                synth_model=synth_model,
-                answer_instruction=answer_instruction, indepth_instruction=indepth_instruction,
-                response_format=response_format, validator_model=validator_model,
-                validator_prompt=validator_prompt,
-                synth_temperature=synth_temp, synth_repeat_penalty=synth_rp, synth_dry=synth_dry,
-                validator_temperature=val_temp, validator_repeat_penalty=val_rp, validator_dry=val_dry,
-                max_tokens=max_tokens, max_loops=validator_max_loops)
+            content, synth_steps, answer_conf, indepth_conf, answer_text, claims = \
+                await _synthesize_and_validate(
+                    client,
+                    base_messages=list(messages), gathered=gathered, chart=chart,
+                    synth_model=synth_model,
+                    answer_instruction=answer_instruction, indepth_instruction=indepth_instruction,
+                    response_format=response_format, validator_model=validator_model,
+                    validator_prompt=validator_prompt,
+                    synth_temperature=synth_temp, synth_repeat_penalty=synth_rp, synth_dry=synth_dry,
+                    validator_temperature=val_temp, validator_repeat_penalty=val_rp, validator_dry=val_dry,
+                    max_tokens=max_tokens, max_loops=validator_max_loops)
             _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
                          synthesizer=synth_model, validator=validator_model,
-                         steps=orch_steps + synth_steps, disposition=disposition)
+                         steps=orch_steps + synth_steps,
+                         answer_confidence=answer_conf, indepth_confidence=indepth_conf,
+                         answer_text=answer_text, in_depth_claims=claims)
             return content
         except Exception as e:
             logger.error("synthesis failed: %s", e, exc_info=True)
 
     _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
-                 synthesizer=synth_model, validator=validator_model,
-                 steps=orch_steps, disposition="synth_failed")
+                 synthesizer=synth_model, validator=validator_model, steps=orch_steps,
+                 answer_confidence={"level": "red", "note": "The team could not produce an answer this turn."},
+                 indepth_confidence={"level": "green", "note": ""})
     return _fallback_envelope(
         "I could not produce a complete answer for this turn. Please try again.")

--- a/server/team.py
+++ b/server/team.py
@@ -412,21 +412,28 @@ async def _audit_and_revise(
     max_tokens: Optional[int],
     max_loops: int,
 ) -> str:
-    """Post-synthesis audit round: validate the draft, and on a flag append specific
-    feedback + re-synthesize, up to max_loops cycles. Returns the (possibly revised)
-    envelope. Never raises — any validator/re-synth failure keeps the current draft."""
-    for _ in range(max(0, max_loops)):
+    """Post-synthesis audit round with a RE-VALIDATE-AND-KEEP-BEST gate: validate the
+    draft; on a flag, re-synthesize with specific feedback and RE-AUDIT the revision —
+    adopt it only if it now passes, otherwise keep the original. A still-flagged rewrite
+    is never trusted over the original (false-flag / drift safety; the literature shows
+    unconditional self-revision can turn a correct answer wrong). Never raises — any
+    validator/re-synth failure keeps the current draft (fail-open)."""
+
+    async def _audit(draft: str) -> Optional[Dict[str, Any]]:
         try:
-            verdict = await _run_validator(
+            return await _run_validator(
                 client, validator_model, validator_prompt,
-                chart=chart, gathered=gathered, answer=content, max_tokens=max_tokens,
+                chart=chart, gathered=gathered, answer=draft, max_tokens=max_tokens,
                 temperature=validator_temperature, repeat_penalty=validator_repeat_penalty,
                 dry_multiplier=validator_dry)
         except Exception as e:
-            logger.warning("validator call failed, keeping draft: %s", e)
-            return content
-        if verdict.get("ok", True):
-            return content
+            logger.warning("validator call failed: %s", e)
+            return None  # fail-open
+
+    for _ in range(max(0, max_loops)):
+        verdict = await _audit(content)
+        if verdict is None or verdict.get("ok", True):
+            return content  # clean (or validator unavailable) -> keep draft
         revise_messages = synth_messages + [
             {"role": "assistant", "content": content},
             {"role": "user", "content": _validator_feedback(verdict)},
@@ -438,11 +445,15 @@ async def _audit_and_revise(
                 max_tokens=max_tokens, repeat_penalty=synth_repeat_penalty,
                 dry_multiplier=synth_dry)
             revised = _normalize_envelope(_message_text(msg))
-            if revised:
-                content = revised
         except Exception as e:
             logger.warning("re-synthesis after validator flag failed, keeping draft: %s", e)
             return content
+        if not revised:
+            return content  # empty revision -> keep original
+        revised_verdict = await _audit(revised)
+        if revised_verdict is not None and revised_verdict.get("ok", False):
+            return revised  # revision cleared the flags -> adopt it
+        return content  # revision still flagged -> keep the original draft
     return content
 
 

--- a/server/team.py
+++ b/server/team.py
@@ -6,8 +6,11 @@ Flow (prompt-driven, not a hardcoded pipeline): the orchestrator (Gemma-4-E4B)
 runs a short tool loop under its OWN system prompt — it is *strongly suggested*
 to call `kb_search` first for guideline/dose/threshold questions, then
 `medical_expert` (MedGemma) which reasons GIVEN the retrieved KB context, then
-stop. A final synthesis call — bound to chartsearchai's response_format — composes
-the strict {answer, citations, blocks} envelope from the gathered evidence.
+stop. Generation is then TWO distinct calls: an Answer synthesis (bound to
+chartsearchai's response_format) and a separate In-Depth synthesis that elaborates
+that answer. Each has its own validator, and the two are combined into a single
+markdown body ("**Answer**\n...\n\n**In Depth**\n- ...") only at the chartsearchai
+handoff, which still receives the strict {answer, citations, blocks} envelope.
 
 Design notes (see specs/artifacts/planning/react-team-orchestration-design.md):
 - The tool loop runs on its own message list under the orchestrator prompt, NOT
@@ -306,23 +309,53 @@ def _normalize_envelope(raw: str) -> str:
 # is the lever we send. (frequency_penalty here was previously a confirmed no-op.)
 _SYNTH_MIN_TEMPERATURE = 0.5
 
-# The validator returns a structured verdict. The Answer and the In Depth are judged on
-# DIFFERENT terms (their scope differs): the Answer is a strict, all-or-nothing chart-accuracy
-# gate; the In Depth is judged claim-by-claim, and the verdict names the specific claim numbers
-# to drop (block/strip). The two drive two INDEPENDENT remediation paths in _audit_and_revise.
-_VALIDATOR_RF = {
+# The Answer and the In Depth are DISTINCT from generation onward: two synthesis calls,
+# two validators. The In-Depth synthesis returns a list of claim strings; the In-Depth
+# validator returns the 1-based claim numbers to drop; the Answer validator returns a
+# strict pass/fail verdict with the reason. The Answer and In-Depth bodies are combined
+# into one markdown body only at the chartsearchai handoff.
+_INDEPTH_RF = {
     "type": "json_schema",
     "json_schema": {
-        "name": "validator_verdict",
+        "name": "in_depth",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "claims": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["claims"],
+        },
+    },
+}
+
+
+_ANSWER_VERDICT_RF = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "answer_verdict",
         "schema": {
             "type": "object",
             "properties": {
                 "answer_ok": {"type": "boolean"},
                 "answer_issues": {"type": "string"},
-                "indepth_drop": {"type": "array", "items": {"type": "integer"}},
-                "indepth_issues": {"type": "string"},
             },
-            "required": ["answer_ok", "indepth_drop"],
+            "required": ["answer_ok"],
+        },
+    },
+}
+
+
+_INDEPTH_VERDICT_RF = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "indepth_verdict",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "drop": {"type": "array", "items": {"type": "integer"}},
+                "issues": {"type": "string"},
+            },
+            "required": ["drop"],
         },
     },
 }
@@ -334,61 +367,6 @@ _VALIDATOR_ABSTAIN_MSG = (
 )
 
 
-_INDEPTH_HEADER_RE = re.compile(r"\*\*\s*in[\s\-]?depth\s*\*\*", re.IGNORECASE)
-_INDEPTH_BULLET_RE = re.compile(r"^\s*(?:[-*•]\s+|\d+[.)]\s+)")
-
-
-def _split_answer_indepth(answer_text: str) -> Tuple[str, List[str]]:
-    """Split a synthesized answer string into (answer_part, indepth_claims). The In Depth is
-    emitted as a markdown bullet list — one claim per bullet — so each claim is individually
-    addressable for claim-level validation. Returns claims=[] when there is no In Depth. If the
-    In-Depth body has no bullets it is treated as ONE claim, so it stays addressable either way."""
-    parts = _INDEPTH_HEADER_RE.split(answer_text or "", maxsplit=1)
-    answer_part = parts[0].rstrip()
-    if len(parts) < 2 or not parts[1].strip():
-        return answer_part, []
-    body = parts[1].strip()
-    lines = [ln for ln in body.splitlines() if ln.strip()]
-    if any(_INDEPTH_BULLET_RE.match(ln) for ln in lines):
-        claims = [_INDEPTH_BULLET_RE.sub("", ln).strip() for ln in lines if _INDEPTH_BULLET_RE.match(ln)]
-    else:
-        claims = [body.strip()]  # not bulleted -> one addressable claim
-    return answer_part, [c for c in claims if c]
-
-
-def _rebuild_answer(answer_part: str, claims: List[str]) -> str:
-    """Reassemble the answer string from the Answer part + the surviving In-Depth claim bullets.
-    With no claim left, ship just the Answer + a brief withheld note — an In-Depth-only miss
-    trims the elaboration, it never blocks the turn (advisory)."""
-    answer_part = answer_part.rstrip()
-    if not claims:
-        return answer_part + (
-            "\n\n_(Supporting detail withheld — it could not be grounded in the chart or the cited guidance.)_")
-    return answer_part + "\n\n**In Depth**\n" + "\n".join("- " + c for c in claims)
-
-
-def _strip_indepth_claims(envelope_json: str, drop: List[int]) -> str:
-    """Block/strip remediation: remove the 1-based In-Depth claim indices in `drop`, keep the
-    rest, leave the **Answer** untouched. Returns the envelope JSON unchanged if there is
-    nothing to drop / it is unparseable / there is no In Depth."""
-    dropset = {d for d in (drop or []) if isinstance(d, int)}
-    if not dropset:
-        return envelope_json
-    try:
-        env = json.loads(envelope_json)
-    except (json.JSONDecodeError, TypeError):
-        return envelope_json
-    ans = env.get("answer")
-    if not isinstance(ans, str):
-        return envelope_json
-    answer_part, claims = _split_answer_indepth(ans)
-    if not claims:
-        return envelope_json
-    kept = [c for i, c in enumerate(claims, start=1) if i not in dropset]
-    env["answer"] = _rebuild_answer(answer_part, kept)
-    return json.dumps(env)
-
-
 def _knob(knobs: Optional[Dict[str, Any]], role: str, key: str, default: Any) -> Any:
     """Resolve one per-role sampling knob from a level's `knobs` block, falling back to
     the global default when the role or key is unset. knobs = {role: {key: value}}."""
@@ -398,86 +376,220 @@ def _knob(knobs: Optional[Dict[str, Any]], role: str, key: str, default: Any) ->
     return default
 
 
-def _validator_feedback(verdict: Dict[str, Any]) -> str:
-    """Answer-focused re-synthesis guidance. The In Depth is remediated separately (claim-level
-    block/strip), so the re-synthesis only needs to fix the direct Answer."""
-    parts = ["Your goal is an accurate direct **Answer**, grounded only in the patient chart."]
+def _answer_body(answer_text: str, claims: List[str]) -> str:
+    """Combine the direct Answer and the In-Depth claims into one markdown body. The Answer
+    leads under a **Answer** header; non-empty claims follow as a **In Depth** bullet list."""
+    body = "**Answer**\n" + (answer_text or "").strip()
+    if claims:
+        body += "\n\n**In Depth**\n" + "\n".join("- " + c for c in claims)
+    return body
+
+
+def _assemble_envelope(
+    answer_text: str, citations: List[int], blocks: List[Any], claims: List[str]
+) -> str:
+    """Serialize the chartsearchai {answer, citations, blocks} envelope, where `answer` is the
+    combined Answer + In-Depth markdown body."""
+    return json.dumps({
+        "answer": _answer_body(answer_text, claims),
+        "citations": citations or [],
+        "blocks": blocks or [],
+    })
+
+
+def _answer_fields(normalized_json_str: str) -> Tuple[str, List[int], List[Any]]:
+    """Pull (answer_text, citations, blocks) out of a normalized envelope JSON string. Tolerant:
+    returns ("", [], []) on any junk / non-object / missing fields."""
+    try:
+        env = json.loads(normalized_json_str)
+    except (json.JSONDecodeError, TypeError):
+        return "", [], []
+    if not isinstance(env, dict):
+        return "", [], []
+    ans = env.get("answer")
+    answer_text = ans.strip() if isinstance(ans, str) else ""
+    citations = [c for c in (env.get("citations") or []) if isinstance(c, int)]
+    blocks = env.get("blocks") if isinstance(env.get("blocks"), list) else []
+    return answer_text, citations, blocks
+
+
+def _answer_feedback(verdict: Dict[str, Any]) -> str:
+    """Answer-focused re-synthesis guidance from the Answer verdict. The In Depth is generated
+    separately, so this only steers the direct Answer."""
+    parts = ["Your goal is an accurate direct answer, grounded only in the patient chart."]
     ai = (verdict.get("answer_issues") or "").strip()
     if ai:
-        parts.append("A reviewer found this problem with the Answer: " + ai)
+        parts.append("A reviewer found this problem with the answer: " + ai)
     parts.append(
-        "Rewrite the **Answer** to be correct using only chart-supported facts; where the chart "
-        "lacks the information, say 'not documented'. Keep the **In Depth** section as well.")
+        "Rewrite the direct answer to be correct using only chart-supported facts; where the chart "
+        "lacks the information, say 'not documented'.")
     return "\n".join(parts)
 
 
-async def _run_validator(
+async def _synthesize_answer(
+    client: httpx.AsyncClient,
+    synth_model: str,
+    base_messages: List[Dict[str, Any]],
+    answer_instruction: str,
+    gathered: str,
+    *,
+    response_format: Optional[Dict[str, Any]],
+    temperature: float,
+    max_tokens: Optional[int],
+    repeat_penalty: Optional[float],
+    dry: Optional[float],
+    extra_msgs: Optional[List[Dict[str, Any]]] = None,
+) -> Tuple[str, List[int], List[Any]]:
+    """Answer synthesis bound to chartsearchai's response_format. Returns the (answer_text,
+    citations, blocks) parsed from the envelope. FAIL-OPEN: returns ("", [], []) on any error."""
+    user = answer_instruction + ("\n\n" + gathered if gathered else "")
+    messages = list(base_messages) + [{"role": "user", "content": user}] + (extra_msgs or [])
+    try:
+        msg = await _chat(
+            client, synth_model, messages,
+            response_format=response_format, temperature=temperature,
+            max_tokens=max_tokens, repeat_penalty=repeat_penalty, dry_multiplier=dry)
+        return _answer_fields(_normalize_envelope(_message_text(msg)))
+    except Exception as e:
+        logger.warning("answer synthesis failed: %s", e)
+        return "", [], []
+
+
+async def _synthesize_indepth(
+    client: httpx.AsyncClient,
+    synth_model: str,
+    base_messages: List[Dict[str, Any]],
+    indepth_instruction: str,
+    gathered: str,
+    answer_text: str,
+    *,
+    temperature: float,
+    max_tokens: Optional[int],
+    repeat_penalty: Optional[float],
+    dry: Optional[float],
+) -> List[str]:
+    """In-Depth synthesis: elaborate the already-produced direct answer into a list of claim
+    strings (one addressable claim each). FAIL-OPEN: returns [] on any error."""
+    user = (
+        indepth_instruction
+        + "\n\n=== DIRECT ANSWER (elaborate THIS; do not restate it) ===\n" + answer_text
+        + ("\n\n=== GATHERED KB / EVIDENCE ===\n" + gathered if gathered else "")
+    )
+    messages = list(base_messages) + [{"role": "user", "content": user}]
+    try:
+        msg = await _chat(
+            client, synth_model, messages,
+            response_format=_INDEPTH_RF, temperature=temperature,
+            max_tokens=max_tokens, repeat_penalty=repeat_penalty, dry_multiplier=dry)
+        obj = json.loads(_message_text(msg))
+    except (Exception,):  # parse OR call failure -> no elaboration
+        logger.warning("in-depth synthesis failed -> no elaboration")
+        return []
+    if not isinstance(obj, dict):
+        return []
+    return [c.strip() for c in (obj.get("claims") or []) if isinstance(c, str) and c.strip()]
+
+
+async def _validate_answer(
     client: httpx.AsyncClient,
     validator_model: str,
-    validator_prompt: Optional[str],
     *,
     chart: str,
     gathered: str,
-    answer: str,
+    answer_text: str,
     max_tokens: Optional[int],
-    temperature: float = 0.0,
-    repeat_penalty: Optional[float] = None,
-    dry_multiplier: Optional[float] = None,
+    temperature: float,
+    repeat_penalty: Optional[float],
+    dry: Optional[float],
+    validation_prompt: str = "validation",
 ) -> Dict[str, Any]:
-    """One audit pass. The Answer is judged strictly for chart-accuracy; the In Depth is judged
-    claim-by-claim (chart-claims vs the chart; guideline-claims for not-fabricated + attributed +
-    relevantly applied). Returns {answer_ok, answer_issues, indepth_drop:[1-based claim #s to
-    remove], indepth_issues}. Fails OPEN (answer_ok=True, indepth_drop=[]) on any malformed
-    verdict so a flaky validator never blocks the run. `indepth_drop` is clamped to real claim #s."""
-    instruction = load_prompt(validator_prompt or "validation")
-    try:
-        obj = json.loads(answer)
-        answer_text = obj.get("answer", answer) if isinstance(obj, dict) else answer
-    except (json.JSONDecodeError, TypeError):
-        answer_text = answer
-    answer_part, claims = _split_answer_indepth(answer_text)
-    numbered = "\n".join(f"{i}. {c}" for i, c in enumerate(claims, start=1)) or "(no In-Depth claims)"
+    """Audit the direct Answer for chart-accuracy. Returns {answer_ok, answer_issues}. FAIL-OPEN:
+    {answer_ok: True} on any parse failure so a flaky validator never blocks the run."""
+    instruction = load_prompt(validation_prompt + "-answer")
     audit_user = (
         instruction
         + "\n\n=== PATIENT CHART (ground truth) ===\n" + (chart or "(none)")
         + "\n\n=== GATHERED KB / EVIDENCE (the guidance the team retrieved) ===\n" + (gathered or "(none)")
-        + "\n\n=== DRAFT ANSWER (judge strictly for chart-accuracy) ===\n" + answer_part
-        + "\n\n=== IN-DEPTH CLAIMS (numbered; return the numbers to DROP) ===\n" + numbered
+        + "\n\n=== DRAFT ANSWER ===\n" + answer_text
     )
     msg = await _chat(
         client, validator_model, [{"role": "user", "content": audit_user}],
-        response_format=_VALIDATOR_RF, temperature=temperature, max_tokens=max_tokens,
-        repeat_penalty=repeat_penalty, dry_multiplier=dry_multiplier)
+        response_format=_ANSWER_VERDICT_RF, temperature=temperature, max_tokens=max_tokens,
+        repeat_penalty=repeat_penalty, dry_multiplier=dry)
     raw = _message_text(msg)
     try:
         verdict = json.loads(raw)
     except (json.JSONDecodeError, TypeError):
-        logger.warning("validator[%s] verdict UNPARSEABLE -> FAIL-OPEN (pass); chart=%dch gathered=%dch raw=%r",
-                       validator_model, len(chart or ""), len(gathered or ""), raw[:240])
-        return {"answer_ok": True, "indepth_drop": []}
+        logger.warning("answer-validator[%s] verdict UNPARSEABLE -> FAIL-OPEN (pass); raw=%r",
+                       validator_model, raw[:240])
+        return {"answer_ok": True}
     if not isinstance(verdict, dict):
-        logger.warning("validator[%s] verdict not an object -> FAIL-OPEN; raw=%r", validator_model, raw[:240])
-        return {"answer_ok": True, "indepth_drop": []}
-    drop = [d for d in (verdict.get("indepth_drop") or []) if isinstance(d, int) and 1 <= d <= len(claims)]
-    verdict["indepth_drop"] = drop
-    logger.info("validator[%s] answer_ok=%s drop=%s/%d claims answer_issues=%r indepth_issues=%r (chart=%dch gathered=%dch)",
-                validator_model, verdict.get("answer_ok"), drop, len(claims),
-                (verdict.get("answer_issues") or "")[:160], (verdict.get("indepth_issues") or "")[:120],
-                len(chart or ""), len(gathered or ""))
+        logger.warning("answer-validator[%s] verdict not an object -> FAIL-OPEN; raw=%r",
+                       validator_model, raw[:240])
+        return {"answer_ok": True}
+    logger.info("answer-validator[%s] answer_ok=%s answer_issues=%r",
+                validator_model, verdict.get("answer_ok"), (verdict.get("answer_issues") or "")[:160])
     return verdict
 
 
-async def _audit_and_revise(
+async def _validate_indepth(
     client: httpx.AsyncClient,
-    content: str,
-    *,
     validator_model: str,
-    validator_prompt: Optional[str],
+    *,
     chart: str,
     gathered: str,
+    answer_text: str,
+    claims: List[str],
+    max_tokens: Optional[int],
+    temperature: float,
+    repeat_penalty: Optional[float],
+    dry: Optional[float],
+    validation_prompt: str = "validation",
+) -> List[int]:
+    """Audit the In-Depth claims claim-by-claim. Returns the 1-based claim numbers to DROP,
+    clamped to 1..len(claims). FAIL-OPEN: returns [] on any parse failure."""
+    instruction = load_prompt(validation_prompt + "-indepth")
+    numbered = "\n".join(f"{i}. {c}" for i, c in enumerate(claims, start=1))
+    audit_user = (
+        instruction
+        + "\n\n=== PATIENT CHART (ground truth) ===\n" + (chart or "(none)")
+        + "\n\n=== GATHERED KB / EVIDENCE (the guidance the team retrieved) ===\n" + (gathered or "(none)")
+        + "\n\n=== DIRECT ANSWER (context) ===\n" + answer_text
+        + "\n\n=== IN-DEPTH CLAIMS (numbered; return the numbers to DROP) ===\n" + numbered
+    )
+    msg = await _chat(
+        client, validator_model, [{"role": "user", "content": audit_user}],
+        response_format=_INDEPTH_VERDICT_RF, temperature=temperature, max_tokens=max_tokens,
+        repeat_penalty=repeat_penalty, dry_multiplier=dry)
+    raw = _message_text(msg)
+    try:
+        verdict = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("indepth-validator[%s] verdict UNPARSEABLE -> FAIL-OPEN (keep all); raw=%r",
+                       validator_model, raw[:240])
+        return []
+    if not isinstance(verdict, dict):
+        logger.warning("indepth-validator[%s] verdict not an object -> FAIL-OPEN; raw=%r",
+                       validator_model, raw[:240])
+        return []
+    drop = [d for d in (verdict.get("drop") or []) if isinstance(d, int) and 1 <= d <= len(claims)]
+    logger.info("indepth-validator[%s] drop=%s/%d claims issues=%r",
+                validator_model, drop, len(claims), (verdict.get("issues") or "")[:120])
+    return drop
+
+
+async def _synthesize_and_validate(
+    client: httpx.AsyncClient,
+    *,
+    base_messages: List[Dict[str, Any]],
+    gathered: str,
+    chart: str,
     synth_model: str,
-    synth_messages: List[Dict[str, Any]],
+    answer_instruction: str,
+    indepth_instruction: str,
     response_format: Optional[Dict[str, Any]],
+    validator_model: Optional[str],
+    validator_prompt: Optional[str] = None,
     synth_temperature: float,
     synth_repeat_penalty: Optional[float],
     synth_dry: Optional[float],
@@ -487,73 +599,91 @@ async def _audit_and_revise(
     max_tokens: Optional[int],
     max_loops: int,
 ) -> str:
-    """Post-synthesis audit driving TWO INDEPENDENT remediation paths off one verdict — because
-    the Answer and the In Depth have different scope and stakes:
+    """Two-call generation + two independent validators, combined into one envelope only here.
 
-      ANSWER (strict): if the direct Answer is flagged, re-synthesize it (Answer-focused feedback)
-        and re-audit, up to `max_loops`; if it still can't be made chart-accurate, ABSTAIN the turn
-        (never ship a wrong fact).
-      IN DEPTH (advisory, claim-level): block/strip exactly the claims the validator flags; the
-        Answer is never touched and an In-Depth miss never abstains the turn.
+      ANSWER (strict): synthesize the direct answer; if the Answer validator flags it WITH a
+        reason, re-synthesize (Answer-focused feedback) and re-validate up to `max_loops`. If it
+        still cannot be made chart-accurate, ABSTAIN the turn. A reasonless flag (answer_ok=False
+        with empty answer_issues) is treated as PASS so noise never abstains.
+      IN DEPTH (advisory, claim-level): synthesize claims from the final answer, then drop exactly
+        the claims the In-Depth validator flags. Never abstains the turn.
 
-    The only coupling is logical: if the Answer abstains there is no elaboration to ship. Never
-    raises — a validator outage fails OPEN (ship the draft); a NEGATIVE Answer verdict that cannot
-    be fixed abstains (we know the Answer is wrong)."""
+    FAIL-OPEN throughout: a validator outage ships the draft; only a reasoned, unfixable NEGATIVE
+    Answer verdict abstains."""
+    answer_text, citations, blocks = await _synthesize_answer(
+        client, synth_model, base_messages, answer_instruction, gathered,
+        response_format=response_format, temperature=synth_temperature,
+        max_tokens=max_tokens, repeat_penalty=synth_repeat_penalty, dry=synth_dry)
+    if not answer_text:
+        return _fallback_envelope(
+            "I could not produce a complete answer for this turn. Please try again.")
 
-    async def _audit(draft: str) -> Optional[Dict[str, Any]]:
+    # --- ANSWER path -----------------------------------------------------
+    if validator_model:
+        async def _audit(draft: str) -> Optional[Dict[str, Any]]:
+            try:
+                return await _validate_answer(
+                    client, validator_model, chart=chart, gathered=gathered, answer_text=draft,
+                    max_tokens=max_tokens, temperature=validator_temperature,
+                    repeat_penalty=validator_repeat_penalty, dry=validator_dry,
+                    validation_prompt=validator_prompt or "validation")
+            except Exception as e:
+                logger.warning("answer-validator call failed: %s", e)
+                return None  # fail-open
+
+        def _passed(verdict: Optional[Dict[str, Any]]) -> bool:
+            # Pass when: no verdict (fail-open), answer_ok True, OR a reasonless False flag.
+            if verdict is None or verdict.get("answer_ok", True):
+                return True
+            return not (verdict.get("answer_issues") or "").strip()
+
+        v = await _audit(answer_text)
+        if not _passed(v):
+            fixed = False
+            for _ in range(max(0, max_loops)):
+                logger.info("answer-validator: Answer flagged -> re-synthesizing")
+                attempt_text, attempt_cit, attempt_blk = await _synthesize_answer(
+                    client, synth_model, base_messages, answer_instruction, gathered,
+                    response_format=response_format, temperature=synth_temperature,
+                    max_tokens=max_tokens, repeat_penalty=synth_repeat_penalty, dry=synth_dry,
+                    extra_msgs=[
+                        {"role": "assistant",
+                         "content": _assemble_envelope(answer_text, citations, blocks, [])},
+                        {"role": "user", "content": _answer_feedback(v)},
+                    ])
+                if not attempt_text:
+                    break  # cannot fix a known-wrong Answer -> abstain
+                answer_text, citations, blocks = attempt_text, attempt_cit, attempt_blk
+                v = await _audit(answer_text)
+                if _passed(v):
+                    logger.info("answer-validator: revision fixed the Answer -> adopt")
+                    fixed = True
+                    break
+            if not fixed:
+                logger.info("answer-validator: Answer still flagged -> ABSTAINING")
+                return _fallback_envelope(_VALIDATOR_ABSTAIN_MSG)
+
+    # --- IN-DEPTH path ---------------------------------------------------
+    claims = await _synthesize_indepth(
+        client, synth_model, base_messages, indepth_instruction, gathered, answer_text,
+        temperature=synth_temperature, max_tokens=max_tokens,
+        repeat_penalty=synth_repeat_penalty, dry=synth_dry)
+    if validator_model and claims:
         try:
-            return await _run_validator(
-                client, validator_model, validator_prompt,
-                chart=chart, gathered=gathered, answer=draft, max_tokens=max_tokens,
+            drop = await _validate_indepth(
+                client, validator_model, chart=chart, gathered=gathered,
+                answer_text=answer_text, claims=claims, max_tokens=max_tokens,
                 temperature=validator_temperature, repeat_penalty=validator_repeat_penalty,
-                dry_multiplier=validator_dry)
+                dry=validator_dry, validation_prompt=validator_prompt or "validation")
         except Exception as e:
-            logger.warning("validator call failed: %s", e)
-            return None  # fail-open
-
-    def _apply_indepth(draft: str, verdict: Dict[str, Any]) -> str:
-        """IN-DEPTH path: block/strip the flagged claims (Answer untouched)."""
-        drop = verdict.get("indepth_drop") or []
+            logger.warning("indepth-validator call failed: %s", e)
+            drop = []  # fail-open
         if drop:
-            logger.info("validator: In Depth claims %s flagged -> block/strip (Answer untouched)", drop)
-            return _strip_indepth_claims(draft, drop)
-        return draft
+            logger.info("indepth-validator: claims %s flagged -> block/strip", drop)
+            dropset = set(drop)
+            claims = [c for i, c in enumerate(claims, start=1) if i not in dropset]
 
-    v = await _audit(content)
-    if v is None:
-        return content  # validator unavailable -> fail-open (we have no verdict)
-
-    # ANSWER sound -> ship it, then run the In-Depth path independently.
-    if v.get("answer_ok", True):
-        return _apply_indepth(content, v)
-
-    # ANSWER flagged -> its own remediation path (re-synthesize, re-audit, else abstain).
-    current, cur_verdict = content, v
-    for _ in range(max(0, max_loops)):
-        logger.info("validator: Answer flagged -> re-synthesizing (In Depth handled separately)")
-        revise_messages = synth_messages + [
-            {"role": "assistant", "content": current},
-            {"role": "user", "content": _validator_feedback(cur_verdict)},
-        ]
-        try:
-            msg = await _chat(
-                client, synth_model, revise_messages,
-                response_format=response_format, temperature=synth_temperature,
-                max_tokens=max_tokens, repeat_penalty=synth_repeat_penalty,
-                dry_multiplier=synth_dry)
-            revised = _normalize_envelope(_message_text(msg))
-        except Exception as e:
-            logger.warning("re-synthesis after validator flag failed: %s", e)
-            break  # cannot fix a known-wrong Answer -> abstain
-        if not revised:
-            break
-        rv = await _audit(revised)
-        if rv is None or rv.get("answer_ok", True):
-            logger.info("validator: revision fixed the Answer -> adopt (then run In-Depth path)")
-            return _apply_indepth(revised, rv or {"indepth_drop": []})
-        current, cur_verdict = revised, rv
-    logger.info("validator: Answer still flagged -> ABSTAINING (never ship a wrong answer)")
-    return _fallback_envelope(_VALIDATOR_ABSTAIN_MSG)
+    return _assemble_envelope(answer_text, citations, blocks, claims)
 
 
 async def run_team(
@@ -607,7 +737,12 @@ async def run_team(
     # each turn.
     orchestrator_system = load_prompt(orchestrator_prompt or "orchestrator")
     expert_system = load_prompt(expert_prompt or "medical_expert")
-    synthesis_instruction = load_prompt(synthesizer_prompt or "synthesis")
+    # Two-call synthesis: the level's synthesis_prompt / validator_prompt are BASE names; each
+    # role's answer/in-depth prompt is "<base>-answer" / "<base>-indepth" (default base
+    # "synthesis" / "validation"). A level can swap the whole set by overriding the base.
+    _synth_base = synthesizer_prompt or "synthesis"
+    answer_instruction = load_prompt(_synth_base + "-answer")
+    indepth_instruction = load_prompt(_synth_base + "-indepth")
 
     # The tool loop runs under the orchestrator's OWN system prompt — not
     # chartsearchai's envelope prompt, which biases a small model toward answering
@@ -666,36 +801,25 @@ async def run_team(
         except Exception as e:
             logger.warning("orchestrator tool loop failed, proceeding to synthesis: %s", e)
 
-        # --- final synthesis (constrained to the envelope) ------------------
-        # Rebuild from the ORIGINAL prefix (byte-identical for LM Studio's cache);
-        # append the gathered evidence + instruction as the last user turn, so the
-        # decisive evidence sits at the end of the array (lost-in-the-middle).
+        # --- generation: two distinct calls (answer + in-depth), each validated,
+        # combined into one envelope. The base prefix is the ORIGINAL chartsearchai
+        # array (byte-identical for LM Studio's cache); the gathered evidence rides on
+        # the last user turn so decisive evidence sits at the end (lost-in-the-middle).
         gathered = _gathered_evidence(kb_context, expert_notes)
-        synth_user = synthesis_instruction + "\n\n" + gathered if gathered else synthesis_instruction
-        synth_messages = list(messages) + [{"role": "user", "content": synth_user}]
         try:
-            msg = await _chat(
-                client, synth_model, synth_messages,
-                response_format=response_format, temperature=synth_temp,
-                max_tokens=max_tokens, repeat_penalty=synth_rp,
-                dry_multiplier=synth_dry,
-            )
-            content = _normalize_envelope(_message_text(msg))
-            if content:
-                if validator_model:
-                    content = await _audit_and_revise(
-                        client, content,
-                        validator_model=validator_model, validator_prompt=validator_prompt,
-                        chart=chart, gathered=gathered,
-                        synth_model=synth_model, synth_messages=synth_messages,
-                        response_format=response_format,
-                        synth_temperature=synth_temp, synth_repeat_penalty=synth_rp, synth_dry=synth_dry,
-                        validator_temperature=val_temp, validator_repeat_penalty=val_rp, validator_dry=val_dry,
-                        max_tokens=max_tokens, max_loops=validator_max_loops)
-                return content
-            logger.warning("synthesis returned empty content; using fallback envelope")
+            content = await _synthesize_and_validate(
+                client,
+                base_messages=list(messages), gathered=gathered, chart=chart,
+                synth_model=synth_model,
+                answer_instruction=answer_instruction, indepth_instruction=indepth_instruction,
+                response_format=response_format, validator_model=validator_model,
+                validator_prompt=validator_prompt,
+                synth_temperature=synth_temp, synth_repeat_penalty=synth_rp, synth_dry=synth_dry,
+                validator_temperature=val_temp, validator_repeat_penalty=val_rp, validator_dry=val_dry,
+                max_tokens=max_tokens, max_loops=validator_max_loops)
+            return content
         except Exception as e:
-            logger.error("synthesis call failed: %s", e, exc_info=True)
+            logger.error("synthesis failed: %s", e, exc_info=True)
 
     return _fallback_envelope(
         "I could not produce a complete answer for this turn. Please try again.")

--- a/server/team.py
+++ b/server/team.py
@@ -316,11 +316,12 @@ _VALIDATOR_RF = {
         "schema": {
             "type": "object",
             "properties": {
-                "ok": {"type": "boolean"},
+                "answer_ok": {"type": "boolean"},
                 "answer_issues": {"type": "string"},
-                "context_issues": {"type": "string"},
+                "indepth_ok": {"type": "boolean"},
+                "indepth_issues": {"type": "string"},
             },
-            "required": ["ok"],
+            "required": ["answer_ok", "indepth_ok"],
         },
     },
 }
@@ -330,6 +331,22 @@ _VALIDATOR_ABSTAIN_MSG = (
     "I could not produce a reliably grounded answer for this turn — the available chart "
     "data does not clearly support a confident response. Please review the chart directly."
 )
+
+
+def _drop_indepth(envelope_json: str) -> str:
+    """Granular abstain: keep the **Answer** section, drop a flagged **In Depth** elaboration
+    (ship the grounded direct answer rather than abstaining the whole turn)."""
+    try:
+        env = json.loads(envelope_json)
+    except (json.JSONDecodeError, TypeError):
+        return envelope_json
+    ans = env.get("answer") or ""
+    parts = re.split(r"\*\*\s*in[\s\-]?depth\s*\*\*", ans, maxsplit=1, flags=re.IGNORECASE)
+    if len(parts) > 1:
+        env["answer"] = parts[0].rstrip() + (
+            "\n\n_(Detailed elaboration withheld — it could not be fully grounded in the chart.)_")
+        return json.dumps(env)
+    return envelope_json  # no In Depth section found -> unchanged
 
 
 def _knob(knobs: Optional[Dict[str, Any]], role: str, key: str, default: Any) -> Any:
@@ -346,11 +363,11 @@ def _validator_feedback(verdict: Dict[str, Any]) -> str:
     parts = ["Your goal is an accurate Answer and a valid, useful In Depth, grounded only in "
              "the patient chart. A reviewer found these gaps to that goal:"]
     ai = (verdict.get("answer_issues") or "").strip()
-    ci = (verdict.get("context_issues") or "").strip()
+    di = (verdict.get("indepth_issues") or "").strip()
     if ai:
         parts.append("Answer: " + ai)
-    if ci:
-        parts.append("Evidence/context: " + ci)
+    if di:
+        parts.append("In Depth: " + di)
     parts.append(
         "Rewrite to meet the goal: keep what is already accurate, correct the above using only "
         "chart-supported facts, and where the chart lacks the information say 'not documented'.")
@@ -393,15 +410,16 @@ async def _run_validator(
     try:
         verdict = json.loads(raw)
     except (json.JSONDecodeError, TypeError):
-        logger.warning("validator[%s] verdict UNPARSEABLE -> FAIL-OPEN (pass); chart=%dch gathered=%dch max_tokens=%s raw=%r",
-                       validator_model, len(chart or ""), len(gathered or ""), max_tokens, raw[:240])
-        return {"ok": True}
+        logger.warning("validator[%s] verdict UNPARSEABLE -> FAIL-OPEN (pass); chart=%dch gathered=%dch raw=%r",
+                       validator_model, len(chart or ""), len(gathered or ""), raw[:240])
+        return {"answer_ok": True, "indepth_ok": True}
     if not isinstance(verdict, dict):
         logger.warning("validator[%s] verdict not an object -> FAIL-OPEN; raw=%r", validator_model, raw[:240])
-        return {"ok": True}
-    logger.info("validator[%s] ok=%s answer_issues=%r context_issues=%r (chart=%dch gathered=%dch)",
-                validator_model, verdict.get("ok"), (verdict.get("answer_issues") or "")[:200],
-                (verdict.get("context_issues") or "")[:120], len(chart or ""), len(gathered or ""))
+        return {"answer_ok": True, "indepth_ok": True}
+    logger.info("validator[%s] answer_ok=%s indepth_ok=%s answer_issues=%r indepth_issues=%r (chart=%dch gathered=%dch)",
+                validator_model, verdict.get("answer_ok"), verdict.get("indepth_ok"),
+                (verdict.get("answer_issues") or "")[:160], (verdict.get("indepth_issues") or "")[:120],
+                len(chart or ""), len(gathered or ""))
     return verdict
 
 
@@ -425,12 +443,14 @@ async def _audit_and_revise(
     max_tokens: Optional[int],
     max_loops: int,
 ) -> str:
-    """Post-synthesis audit round with a RE-VALIDATE-AND-KEEP-BEST gate: validate the
-    draft; on a flag, re-synthesize with specific feedback and RE-AUDIT the revision —
-    adopt it only if it now passes, otherwise keep the original. A still-flagged rewrite
-    is never trusted over the original (false-flag / drift safety; the literature shows
-    unconditional self-revision can turn a correct answer wrong). Never raises — any
-    validator/re-synth failure keeps the current draft (fail-open)."""
+    """Post-synthesis audit round with GRANULAR, section-aware handling. The validator
+    judges the **Answer** and **In Depth** sections separately:
+      - both clean              -> ship the draft;
+      - Answer ok, In Depth bad -> ship the Answer, DROP the In Depth (don't abstain);
+      - Answer bad              -> re-synthesize; if the Answer is then ok, adopt it
+                                   (dropping the In Depth if still bad); if the Answer is
+                                   still bad, ABSTAIN (never ship a wrong direct answer).
+    Never raises — any validator/re-synth failure keeps the current draft (fail-open)."""
 
     async def _audit(draft: str) -> Optional[Dict[str, Any]]:
         try:
@@ -444,13 +464,16 @@ async def _audit_and_revise(
             return None  # fail-open
 
     for _ in range(max(0, max_loops)):
-        verdict = await _audit(content)
-        if verdict is None or verdict.get("ok", True):
-            return content  # clean (or validator unavailable) -> keep draft
-        logger.info("validator flagged the draft -> re-synthesizing with feedback")
+        v = await _audit(content)
+        if v is None or (v.get("answer_ok", True) and v.get("indepth_ok", True)):
+            return content  # both sections clean (or validator unavailable)
+        if v.get("answer_ok", True):
+            logger.info("validator: Answer ok, In Depth flagged -> keep Answer, drop In Depth")
+            return _drop_indepth(content)  # granular: ship the grounded Answer, drop the bad elaboration
+        logger.info("validator: Answer flagged -> re-synthesizing with feedback")
         revise_messages = synth_messages + [
             {"role": "assistant", "content": content},
-            {"role": "user", "content": _validator_feedback(verdict)},
+            {"role": "user", "content": _validator_feedback(v)},
         ]
         try:
             msg = await _chat(
@@ -464,12 +487,15 @@ async def _audit_and_revise(
             return content
         if not revised:
             return content  # empty revision -> keep original
-        revised_verdict = await _audit(revised)
-        if revised_verdict is not None and revised_verdict.get("ok", False):
-            logger.info("validator: revision cleared the flags -> adopted")
-            return revised  # revision cleared the flags -> adopt it
-        logger.info("validator: revision still flagged -> ABSTAINING (never ship a flagged answer)")
-        return _fallback_envelope(_VALIDATOR_ABSTAIN_MSG)  # don't ship the original OR the bad rewrite
+        rv = await _audit(revised)
+        if rv is None or rv.get("answer_ok", True):
+            if rv is None or rv.get("indepth_ok", True):
+                logger.info("validator: revision fixed the Answer -> adopted")
+                return revised
+            logger.info("validator: revision fixed the Answer, In Depth still flagged -> adopt + drop In Depth")
+            return _drop_indepth(revised)
+        logger.info("validator: Answer still flagged after re-synth -> ABSTAINING (never ship a wrong answer)")
+        return _fallback_envelope(_VALIDATOR_ABSTAIN_MSG)
     return content
 
 

--- a/server/team.py
+++ b/server/team.py
@@ -326,6 +326,12 @@ _VALIDATOR_RF = {
 }
 
 
+_VALIDATOR_ABSTAIN_MSG = (
+    "I could not produce a reliably grounded answer for this turn — the available chart "
+    "data does not clearly support a confident response. Please review the chart directly."
+)
+
+
 def _knob(knobs: Optional[Dict[str, Any]], role: str, key: str, default: Any) -> Any:
     """Resolve one per-role sampling knob from a level's `knobs` block, falling back to
     the global default when the role or key is unset. knobs = {role: {key: value}}."""
@@ -464,8 +470,8 @@ async def _audit_and_revise(
         if revised_verdict is not None and revised_verdict.get("ok", False):
             logger.info("validator: revision cleared the flags -> adopted")
             return revised  # revision cleared the flags -> adopt it
-        logger.info("validator: revision still flagged -> kept the original draft")
-        return content  # revision still flagged -> keep the original draft
+        logger.info("validator: revision still flagged -> ABSTAINING (never ship a flagged answer)")
+        return _fallback_envelope(_VALIDATOR_ABSTAIN_MSG)  # don't ship the original OR the bad rewrite
     return content
 
 

--- a/server/team.py
+++ b/server/team.py
@@ -381,31 +381,18 @@ def _knob(knobs: Optional[Dict[str, Any]], role: str, key: str, default: Any) ->
     return default
 
 
-_CONF_ICON = {"green": "🟢", "yellow": "🟡", "red": "🔴"}
+# Confidence level -> tag label (high=green, medium=yellow, low=red). The hub emits the structured
+# {level, note}; clients (dashboard/report, and chat once its schema is updated) render the tag.
+_CONF_LABEL = {"green": "High confidence", "yellow": "Medium confidence", "red": "Low confidence"}
 
 
-def _caveat(conf: Optional[Dict[str, Any]]) -> str:
-    """A one-line clinician-facing confidence caveat for a section (empty for green / no note)."""
-    if not conf:
-        return ""
-    level = conf.get("level")
-    note = (conf.get("note") or "").strip()
-    if level in (None, "green") or not note:
-        return ""
-    return "\n\n> " + _CONF_ICON.get(level, "") + " " + note
-
-
-def _answer_body(answer_text: str, claims: List[str],
-                 answer_conf: Optional[Dict[str, Any]] = None,
-                 indepth_conf: Optional[Dict[str, Any]] = None) -> str:
-    """Combine the direct Answer and the In-Depth claims into one markdown body, each followed by
-    its confidence caveat (a 🟡/🔴 note; green adds nothing). The Answer leads under a **Answer**
-    header; non-empty claims follow as a **In Depth** bullet list."""
-    body = "**Answer**\n" + (answer_text or "").strip() + _caveat(answer_conf)
+def _answer_body(answer_text: str, claims: List[str]) -> str:
+    """Combine the direct Answer and the In-Depth claims into one CLEAN markdown body (no confidence
+    text baked in — confidence is structured metadata a client renders as a tag). The Answer leads
+    under a **Answer** header; non-empty claims follow as a **In Depth** bullet list."""
+    body = "**Answer**\n" + (answer_text or "").strip()
     if claims:
-        body += "\n\n**In Depth**\n" + "\n".join("- " + c for c in claims) + _caveat(indepth_conf)
-    elif _caveat(indepth_conf):  # red In-Depth with no surviving claims still carries its note
-        body += "\n\n**In Depth**" + _caveat(indepth_conf)
+        body += "\n\n**In Depth**\n" + "\n".join("- " + c for c in claims)
     return body
 
 
@@ -413,12 +400,12 @@ def _assemble_envelope(
     answer_text: str, citations: List[int], blocks: List[Any], claims: List[str],
     answer_conf: Optional[Dict[str, Any]] = None, indepth_conf: Optional[Dict[str, Any]] = None,
 ) -> str:
-    """Serialize the chartsearchai {answer, citations, blocks} envelope, where `answer` is the
-    combined Answer + In-Depth markdown body. Also carries a forward-looking `confidence` block
-    (per-section {level, note}) — chartsearchai drops it today; the harness reads confidence from
-    the reasoning trace, and the markdown caveats render everywhere meanwhile."""
+    """Serialize the chartsearchai {answer, citations, blocks} envelope, where `answer` is the CLEAN
+    combined Answer + In-Depth markdown body. Carries a `confidence` block (per-section {level, note})
+    as structured metadata a client renders as a TAG — chartsearchai drops it today; the harness
+    reads confidence from the reasoning trace, the dashboard/report render the tag."""
     env: Dict[str, Any] = {
-        "answer": _answer_body(answer_text, claims, answer_conf, indepth_conf),
+        "answer": _answer_body(answer_text, claims),
         "citations": citations or [],
         "blocks": blocks or [],
     }
@@ -618,7 +605,7 @@ def _answer_note(level: str, first_issue: str, last_issue: str) -> str:
         base = "An initial draft was flagged on clinical review and corrected on a second pass"
         return base + ((" (first issue: " + first_issue + ")") if first_issue else "") + "."
     if level == "red":
-        return ("Low confidence — clinical review still flagged this after a revision: "
+        return ("Clinical review still flagged this after a revision: "
                 + (last_issue or first_issue or "the answer could not be confirmed against the chart.")
                 + " Verify against the chart before acting.")
     return ""

--- a/server/temporal.py
+++ b/server/temporal.py
@@ -1,0 +1,117 @@
+"""Deterministic temporal grounding for the synthesis evidence (P0 anchor + P1 series).
+
+The synth fabricates dates/trends because it eyeballs the chart. Here we parse the serialized
+chart text server-side and emit a compact block the synth REPORTS from instead of deriving:
+  - a reference-date ANCHOR line (the simulated "now") so "recent"/"most recent" are defined;
+  - per-concept numeric SERIES sorted oldest->newest, with most-recent value+date, range, the
+    data window, and a trend direction ONLY when >=2 points exist (the no-trend-from-one-point guard).
+All relative to the resolved anchor. Pure functions; no LLM, no I/O. Grounded in the real chart
+format (chartsearchai PatientChartSerializer): `[N] (YYYY-MM-DD) <Class> — <concept>: <value> <unit>`.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from typing import Any, Dict, List, Optional
+
+_RECORD_RE = re.compile(r"^\[(\d+)\]\s*\((\d{4}-\d{2}-\d{2})\)\s*(.+)$")
+_DATE_RE = re.compile(r"\((\d{4}-\d{2}-\d{2})\)")
+_ISO_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+_LEADING_NUM_RE = re.compile(r"^([+-]?\d+(?:\.\d+)?)\s*(.*)$")
+
+
+def resolve_anchor(anchor: Optional[str], chart: str) -> Optional[str]:
+    """Resolve the reference 'now' (ISO date).
+       - None / 'latest_record' -> the max (YYYY-MM-DD) in the chart text (data-derived);
+       - 'wall_clock' -> today's date (real clock);
+       - an explicit 'YYYY-MM-DD' -> itself.
+    Returns None when latest_record is requested but the chart has no dates."""
+    mode = (anchor or "latest_record").strip()
+    if mode == "wall_clock":
+        return _dt.date.today().isoformat()
+    if _ISO_RE.fullmatch(mode):
+        return mode
+    dates = _DATE_RE.findall(chart or "")
+    return max(dates) if dates else None
+
+
+def _clean_concept(raw: str) -> str:
+    """'Weight (kg), WT)' -> 'Weight'; 'CD4 count' -> 'CD4 count'; keeps 'CD4%'."""
+    c = raw.strip()
+    cut = c.find(" (")  # drop unit/synonym noise after the first ' ('
+    if cut > 0:
+        c = c[:cut]
+    return c.rstrip(" ),").strip()
+
+
+def parse_dated_observations(chart: str) -> List[Dict[str, Any]]:
+    """Parse `[N] (date) <Class> — <concept>: <value> <unit>` lines into numeric observations:
+       {index, date, concept, value, unit, raw}. Only rows whose value begins with a number (true
+       numeric series) are kept — drug orders / Yes-No assessments are skipped. De-duplicated per
+       (concept, date), keeping the first occurrence (the chart is already one row per date)."""
+    out: List[Dict[str, Any]] = []
+    seen: set = set()
+    for line in (chart or "").splitlines():
+        m = _RECORD_RE.match(line.strip())
+        if not m:
+            continue
+        index, date, rest = int(m.group(1)), m.group(2), m.group(3)
+        if " — " in rest:
+            rest = rest.split(" — ", 1)[1]
+        if ":" not in rest:
+            continue
+        head, _, tail = rest.partition(":")
+        value_text = tail.strip()
+        if _ISO_RE.match(value_text):
+            continue  # a date-valued obs (e.g. "Return visit date: 2006-05-18"), not a measurement
+        nm = _LEADING_NUM_RE.match(value_text)
+        if not nm:
+            continue  # not a numeric obs
+        concept = _clean_concept(head)
+        if not concept:
+            continue
+        key = (concept, date)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append({"index": index, "date": date, "concept": concept,
+                    "value": float(nm.group(1)), "unit": nm.group(2).strip(), "raw": line.strip()})
+    return out
+
+
+def build_temporal_block(chart: str, anchor: Optional[str]) -> str:
+    """The injected evidence block: the anchor line + per-concept series. '' when there's neither
+       an anchor nor any series. The synth/validator read 'most recent' and trends FROM here."""
+    obs = parse_dated_observations(chart)
+    if not anchor and not obs:
+        return ""
+    lines: List[str] = []
+    if anchor:
+        lines.append(
+            f"Current date: {anchor}. Interpret \"current\", \"recent\", and \"most recent\" "
+            f"relative to THIS date; the patient's records may predate it. Use the dated series "
+            f"below verbatim — do not infer dates, values, or trends not shown."
+        )
+    by_concept: Dict[str, List[Dict[str, Any]]] = {}
+    for o in obs:
+        by_concept.setdefault(o["concept"], []).append(o)
+    if by_concept:
+        if lines:
+            lines.append("")
+        lines.append("Computed numeric series (deterministic, oldest→newest):")
+    for concept, series in by_concept.items():
+        series = sorted(series, key=lambda o: o["date"])
+        last = series[-1]
+        unit = (" " + last["unit"]) if last["unit"] else ""
+        if len(series) < 2:
+            lines.append(f"- {concept}: {last['value']}{unit} ({last['date']}) — single measurement.")
+            continue
+        first = series[0]
+        vals = [o["value"] for o in series]
+        direction = "↑" if last["value"] > first["value"] else ("↓" if last["value"] < first["value"] else "→")
+        lines.append(
+            f"- {concept}: most recent {last['value']}{unit} ({last['date']}); "
+            f"{len(series)} values {first['value']}→{last['value']} {direction} "
+            f"over {first['date']}…{last['date']}; range {min(vals)}–{max(vals)}."
+        )
+    return "\n".join(lines)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -48,6 +48,33 @@ def test_run_team_produces_the_envelope_from_the_final_synthesis_call():
     assert env["blocks"] == []
 
 
+def test_parity_lane_single_call_bare_envelope():
+    # The parity lane (two_call=False): orchestration still runs, but synthesis is ONE
+    # chartsearchai-style call (synthesizer_prompt is a WHOLE prompt), validator off, and the
+    # output is the BARE {answer, citations, blocks} envelope -- no **Answer**/**In Depth**
+    # wrapper, no confidence block -- so it matches the direct single-LLM arms' format.
+    rf_calls = []
+
+    async def fake_chat(client, model, messages, *, tools=None, response_format=None,
+                        temperature=None, max_tokens=None, **kwargs):
+        if response_format is not None:
+            rf_calls.append(model)
+            return {"content": ENVELOPE}
+        return {"content": "ok", "tool_calls": None}
+
+    with patch.object(team, "_chat", side_effect=fake_chat):
+        out = run(team.run_team(
+            MESSAGES, response_format=RESP_FORMAT, temperature=0.0, max_tokens=1024,
+            synthesizer_prompt="synthesis-chartsearchai", two_call=False, validator_model=None))
+
+    env = json.loads(out)
+    assert env["answer"] == "Lisinopril 10 mg [1]"          # raw answer, NOT wrapped under **Answer**
+    assert "**Answer**" not in env["answer"] and "**In Depth**" not in env["answer"]
+    assert env["citations"] == [1] and env["blocks"] == []
+    assert "confidence" not in env                           # bare envelope, no confidence block
+    assert len(rf_calls) == 1                                # ONE synthesis call, not the two-call split
+
+
 def test_response_format_is_only_applied_on_the_synthesis_calls():
     # The tool-selection turns must run PLAIN (no response_format); only the
     # synthesis calls are constrained. This is the load-bearing small-model rule.

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -13,9 +13,8 @@ from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
-from server import team
+from server import team, levels_loader
 from server.main import app
-from server.openai_compat import TEAM_PRESETS
 
 ENVELOPE = json.dumps({"answer": "Lisinopril 10 mg [1]", "citations": [1], "blocks": []})
 RESP_FORMAT = {"type": "json_schema", "json_schema": {"name": "chart_answer", "schema": {}}}
@@ -182,12 +181,12 @@ def test_run_team_falls_back_to_a_valid_envelope_when_synthesis_fails():
     assert env["citations"] == [] and env["blocks"] == []
 
 
-def test_v1_models_advertises_the_team_presets():
+def test_v1_models_advertises_the_levels():
     client = TestClient(app)
     r = client.get("/v1/models")
     assert r.status_code == 200
     ids = [m["id"] for m in r.json()["data"]]
-    assert ids == list(TEAM_PRESETS)
+    assert ids == levels_loader.level_ids()
 
 
 def test_chat_completions_team_returns_openai_shape_with_the_envelope():

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -42,14 +42,15 @@ def test_run_team_produces_the_envelope_from_the_final_synthesis_call():
         out = run(team.run_team(MESSAGES, response_format=RESP_FORMAT, temperature=0.0, max_tokens=1024))
 
     env = json.loads(out)
-    assert env["answer"] == "Lisinopril 10 mg [1]"
+    # The Answer synthesis text is wrapped under the **Answer** header in the combined body.
+    assert "**Answer**" in env["answer"] and "Lisinopril 10 mg [1]" in env["answer"]
     assert env["citations"] == [1]
     assert env["blocks"] == []
 
 
-def test_response_format_is_only_applied_on_the_final_synthesis_call():
+def test_response_format_is_only_applied_on_the_synthesis_calls():
     # The tool-selection turns must run PLAIN (no response_format); only the
-    # final synthesis is constrained. This is the load-bearing small-model rule.
+    # synthesis calls are constrained. This is the load-bearing small-model rule.
     seen = []
 
     async def fake_chat(client, model, messages, *, tools=None, response_format=None,
@@ -62,9 +63,9 @@ def test_response_format_is_only_applied_on_the_final_synthesis_call():
 
     # No single call mixes tools + response_format.
     assert all(not (c["tools"] and c["rf"]) for c in seen)
-    # Exactly one constrained (synthesis) call, and it carries no tools.
+    # The two-call synthesis (Answer + In-Depth) — both constrained, neither carries tools.
     rf_calls = [c for c in seen if c["rf"]]
-    assert len(rf_calls) == 1 and rf_calls[0]["tools"] is False
+    assert len(rf_calls) == 2 and all(c["tools"] is False for c in rf_calls)
 
 
 def test_orchestrator_consults_the_medical_expert_on_a_tool_call():

--- a/tests/test_knobs.py
+++ b/tests/test_knobs.py
@@ -28,7 +28,7 @@ def test_per_lane_knobs_route_to_each_role(monkeypatch):
         seen.append({"model": model, "temperature": temperature,
                      "repeat_penalty": repeat_penalty, "dry": dry_multiplier})
         if model == "VAL":
-            return {"content": json.dumps({"ok": False, "answer_issues": "x", "context_issues": ""})}
+            return {"content": json.dumps({"answer_ok": False, "answer_issues": "x", "indepth_ok": True, "indepth_issues": ""})}
         if response_format is not None:
             return {"content": json.dumps({"answer": "ok", "citations": [], "blocks": []})}
         return {"content": "", "tool_calls": None}

--- a/tests/test_knobs.py
+++ b/tests/test_knobs.py
@@ -28,7 +28,7 @@ def test_per_lane_knobs_route_to_each_role(monkeypatch):
         seen.append({"model": model, "temperature": temperature,
                      "repeat_penalty": repeat_penalty, "dry": dry_multiplier})
         if model == "VAL":
-            return {"content": json.dumps({"answer_ok": False, "answer_issues": "x", "indepth_ok": True, "indepth_issues": ""})}
+            return {"content": json.dumps({"answer_ok": False, "answer_issues": "x", "indepth_drop": [], "indepth_issues": ""})}
         if response_format is not None:
             return {"content": json.dumps({"answer": "ok", "citations": [], "blocks": []})}
         return {"content": "", "tool_calls": None}

--- a/tests/test_knobs.py
+++ b/tests/test_knobs.py
@@ -1,7 +1,9 @@
 """Per-lane knobs: a level can set sampling knobs (temperature / repeat_penalty / dry)
 PER ROLE, so any arm is fully reproducible from its level block. Unset roles fall back
 to today's global defaults. Mocks the LM Studio boundary (`_chat`) and asserts each
-role's call carries its configured knobs. Run: pytest tests/test_knobs.py
+role's call carries its configured knobs — including the two-call generation flow
+(Answer synth + In-Depth synth) and the two validators (answer_verdict + indepth_verdict).
+Run: pytest tests/test_knobs.py
 """
 
 import asyncio
@@ -17,26 +19,37 @@ _MESSAGES = [
 _RF = {"type": "json_schema", "json_schema": {"name": "chart_answer"}}
 
 
-def test_per_lane_knobs_route_to_each_role(monkeypatch):
-    """Per-role knobs reach the matching role's _chat call (synthesizer + validator +
-    orchestrator). RED on today's code: run_team has no `knobs` parameter."""
-    seen = []
-
+def _make_chat(seen):
+    """A _chat mock that records each call's knobs and branches on the response_format
+    json_schema name so the synth calls (chart_answer + in_depth) and the validator calls
+    (answer_verdict + indepth_verdict) are all served — like production's four call sites."""
     async def fake_chat(client, model, messages, *, tools=None, response_format=None,
                         temperature=None, max_tokens=None, repeat_penalty=None,
                         dry_multiplier=None, **kwargs):
-        seen.append({"model": model, "temperature": temperature,
+        name = (response_format or {}).get("json_schema", {}).get("name")
+        seen.append({"model": model, "schema": name, "temperature": temperature,
                      "repeat_penalty": repeat_penalty, "dry": dry_multiplier})
-        if model == "VAL":
-            return {"content": json.dumps({"answer_ok": False, "answer_issues": "x", "indepth_drop": [], "indepth_issues": ""})}
-        if response_format is not None:
-            return {"content": json.dumps({"answer": "ok", "citations": [], "blocks": []})}
+        if name == "chart_answer":
+            return {"content": json.dumps({"answer": "ans", "citations": [], "blocks": []})}
+        if name == "in_depth":
+            return {"content": json.dumps({"claims": ["c1", "c2"]})}
+        if name == "answer_verdict":
+            return {"content": json.dumps({"answer_ok": True, "answer_issues": ""})}
+        if name == "indepth_verdict":
+            return {"content": json.dumps({"drop": []})}
         return {"content": "", "tool_calls": None}
+    return fake_chat
 
-    monkeypatch.setattr(team, "_chat", fake_chat)
+
+def test_per_lane_knobs_route_to_each_role(monkeypatch):
+    """Per-role knobs reach the matching role's _chat calls: BOTH synthesis calls (Answer +
+    In-Depth) carry the synth knobs, BOTH validator calls carry the validator knobs, and the
+    orchestrator loop carries the orchestrator knobs."""
+    seen = []
+    monkeypatch.setattr(team, "_chat", _make_chat(seen))
     knobs = {
         "synthesizer": {"temperature": 0.7, "repeat_penalty": 1.3, "dry": 0.5},
-        "validator": {"temperature": 0.9},
+        "validator": {"temperature": 0.9, "repeat_penalty": 1.1, "dry": 0.2},
         "orchestrator": {"temperature": 0.15, "dry": 0.0},
     }
     asyncio.run(team.run_team(
@@ -44,36 +57,37 @@ def test_per_lane_knobs_route_to_each_role(monkeypatch):
         orchestrator_model="ORCH", synthesizer_model="SYNTH",
         validator_model="VAL", validator_max_loops=1, knobs=knobs))
 
-    synth = [c for c in seen if c["model"] == "SYNTH"]
-    val = [c for c in seen if c["model"] == "VAL"]
-    orch = [c for c in seen if c["model"] == "ORCH"]
-    # synthesizer (original + the validator-triggered re-synth) both carry the lane's synth knobs
-    assert synth, seen
+    synth = [c for c in seen if c["schema"] in ("chart_answer", "in_depth")]
+    val = [c for c in seen if c["schema"] in ("answer_verdict", "indepth_verdict")]
+    orch = [c for c in seen if c["schema"] is None]
+
+    # Both the Answer synth (chart_answer) and the In-Depth synth (in_depth) fire and carry the knobs.
+    assert {c["schema"] for c in synth} == {"chart_answer", "in_depth"}, seen
+    assert all(c["model"] == "SYNTH" for c in synth), seen
     assert all(c["temperature"] == 0.7 and c["repeat_penalty"] == 1.3 and c["dry"] == 0.5
                for c in synth), seen
-    assert val and val[0]["temperature"] == 0.9, seen
-    assert orch and orch[0]["temperature"] == 0.15 and orch[0]["dry"] == 0.0, seen
+
+    # Both validators (answer + in-depth) fire and carry the validator knobs.
+    assert {c["schema"] for c in val} == {"answer_verdict", "indepth_verdict"}, seen
+    assert all(c["model"] == "VAL" for c in val), seen
+    assert all(c["temperature"] == 0.9 and c["repeat_penalty"] == 1.1 and c["dry"] == 0.2
+               for c in val), seen
+
+    assert orch and all(c["model"] == "ORCH" for c in orch), seen
+    assert orch[0]["temperature"] == 0.15 and orch[0]["dry"] == 0.0, seen
 
 
 def test_unset_role_knobs_keep_defaults(monkeypatch):
     """With no knobs block, the synthesizer keeps its anti-degeneration defaults
-    (temperature floor + repeat_penalty) — nothing changes vs today."""
+    (temperature floor + repeat_penalty + dry) on BOTH synth calls — nothing changes vs today."""
     seen = []
-
-    async def fake_chat(client, model, messages, *, tools=None, response_format=None,
-                        temperature=None, max_tokens=None, repeat_penalty=None,
-                        dry_multiplier=None, **kwargs):
-        seen.append({"model": model, "temperature": temperature,
-                     "repeat_penalty": repeat_penalty, "dry": dry_multiplier})
-        if response_format is not None:
-            return {"content": json.dumps({"answer": "ok", "citations": [], "blocks": []})}
-        return {"content": "", "tool_calls": None}
-
-    monkeypatch.setattr(team, "_chat", fake_chat)
+    monkeypatch.setattr(team, "_chat", _make_chat(seen))
     asyncio.run(team.run_team(
         _MESSAGES, response_format=_RF, temperature=0.0,
         orchestrator_model="ORCH", synthesizer_model="SYNTH"))
-    synth = [c for c in seen if c["model"] == "SYNTH"][0]
-    assert synth["temperature"] >= team._SYNTH_MIN_TEMPERATURE, synth
-    assert synth["repeat_penalty"] == team.SYNTH_REPEAT_PENALTY, synth
-    assert synth["dry"] == team.SYNTH_DRY_MULTIPLIER, synth
+    synth = [c for c in seen if c["schema"] in ("chart_answer", "in_depth")]
+    assert {c["schema"] for c in synth} == {"chart_answer", "in_depth"}, seen
+    for c in synth:
+        assert c["temperature"] >= team._SYNTH_MIN_TEMPERATURE, c
+        assert c["repeat_penalty"] == team.SYNTH_REPEAT_PENALTY, c
+        assert c["dry"] == team.SYNTH_DRY_MULTIPLIER, c

--- a/tests/test_knobs.py
+++ b/tests/test_knobs.py
@@ -1,0 +1,79 @@
+"""Per-lane knobs: a level can set sampling knobs (temperature / repeat_penalty / dry)
+PER ROLE, so any arm is fully reproducible from its level block. Unset roles fall back
+to today's global defaults. Mocks the LM Studio boundary (`_chat`) and asserts each
+role's call carries its configured knobs. Run: pytest tests/test_knobs.py
+"""
+
+import asyncio
+import json
+
+from server import team
+
+_MESSAGES = [
+    {"role": "system", "content": "s"},
+    {"role": "user", "content": "chart"},
+    {"role": "user", "content": "q"},
+]
+_RF = {"type": "json_schema", "json_schema": {"name": "chart_answer"}}
+
+
+def test_per_lane_knobs_route_to_each_role(monkeypatch):
+    """Per-role knobs reach the matching role's _chat call (synthesizer + validator +
+    orchestrator). RED on today's code: run_team has no `knobs` parameter."""
+    seen = []
+
+    async def fake_chat(client, model, messages, *, tools=None, response_format=None,
+                        temperature=None, max_tokens=None, repeat_penalty=None,
+                        dry_multiplier=None, **kwargs):
+        seen.append({"model": model, "temperature": temperature,
+                     "repeat_penalty": repeat_penalty, "dry": dry_multiplier})
+        if model == "VAL":
+            return {"content": json.dumps({"ok": False, "answer_issues": "x", "context_issues": ""})}
+        if response_format is not None:
+            return {"content": json.dumps({"answer": "ok", "citations": [], "blocks": []})}
+        return {"content": "", "tool_calls": None}
+
+    monkeypatch.setattr(team, "_chat", fake_chat)
+    knobs = {
+        "synthesizer": {"temperature": 0.7, "repeat_penalty": 1.3, "dry": 0.5},
+        "validator": {"temperature": 0.9},
+        "orchestrator": {"temperature": 0.15, "dry": 0.0},
+    }
+    asyncio.run(team.run_team(
+        _MESSAGES, response_format=_RF,
+        orchestrator_model="ORCH", synthesizer_model="SYNTH",
+        validator_model="VAL", validator_max_loops=1, knobs=knobs))
+
+    synth = [c for c in seen if c["model"] == "SYNTH"]
+    val = [c for c in seen if c["model"] == "VAL"]
+    orch = [c for c in seen if c["model"] == "ORCH"]
+    # synthesizer (original + the validator-triggered re-synth) both carry the lane's synth knobs
+    assert synth, seen
+    assert all(c["temperature"] == 0.7 and c["repeat_penalty"] == 1.3 and c["dry"] == 0.5
+               for c in synth), seen
+    assert val and val[0]["temperature"] == 0.9, seen
+    assert orch and orch[0]["temperature"] == 0.15 and orch[0]["dry"] == 0.0, seen
+
+
+def test_unset_role_knobs_keep_defaults(monkeypatch):
+    """With no knobs block, the synthesizer keeps its anti-degeneration defaults
+    (temperature floor + repeat_penalty) — nothing changes vs today."""
+    seen = []
+
+    async def fake_chat(client, model, messages, *, tools=None, response_format=None,
+                        temperature=None, max_tokens=None, repeat_penalty=None,
+                        dry_multiplier=None, **kwargs):
+        seen.append({"model": model, "temperature": temperature,
+                     "repeat_penalty": repeat_penalty, "dry": dry_multiplier})
+        if response_format is not None:
+            return {"content": json.dumps({"answer": "ok", "citations": [], "blocks": []})}
+        return {"content": "", "tool_calls": None}
+
+    monkeypatch.setattr(team, "_chat", fake_chat)
+    asyncio.run(team.run_team(
+        _MESSAGES, response_format=_RF, temperature=0.0,
+        orchestrator_model="ORCH", synthesizer_model="SYNTH"))
+    synth = [c for c in seen if c["model"] == "SYNTH"][0]
+    assert synth["temperature"] >= team._SYNTH_MIN_TEMPERATURE, synth
+    assert synth["repeat_penalty"] == team.SYNTH_REPEAT_PENALTY, synth
+    assert synth["dry"] == team.SYNTH_DRY_MULTIPLIER, synth

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -20,9 +20,9 @@ from server import prompt_loader, team
 
 PROMPTS_DIR = Path(team.__file__).parent / "prompts"
 
-# Distinctive markers in the committed synthesis.txt (its two-section + false-premise
-# instructions); used to prove the synthesis prompt actually reaches the model.
-SYNTH_MARKERS = ("**In Depth**", "FALSE PREMISE")
+# Distinctive markers from the two-call synthesis prompts (synthesis-answer + synthesis-indepth);
+# used to prove BOTH synthesis prompts actually reach the model.
+SYNTH_MARKERS = ("FALSE PREMISE", "DIRECT ANSWER ONLY", "IN-DEPTH elaboration")
 
 ENVELOPE = json.dumps({"answer": "Lisinopril 10 mg [1]", "citations": [1], "blocks": []})
 RESP_FORMAT = {"type": "json_schema", "json_schema": {"name": "chart_answer", "schema": {}}}
@@ -34,23 +34,23 @@ MESSAGES = [
 
 
 def _run_team_capturing_synth():
-    """Run the team and return the JSON-serialized message array sent to the
-    constrained synthesis call — the turn that carries the synthesis prompt.
+    """Run the team and return the JSON-serialized message arrays sent to the constrained
+    synthesis calls — the two turns (Answer + In-Depth) that carry the synthesis prompts.
     `team._chat` is seamed; no model, no HTTP."""
     import asyncio
 
-    captured = {}
+    captured = {"synths": []}
 
     async def fake_chat(client, model, messages, *, tools=None, response_format=None,
                         temperature=None, max_tokens=None, **kwargs):
         if response_format is not None:
-            captured["synth"] = messages
+            captured["synths"].append(messages)
             return {"content": ENVELOPE}
         return {"content": "ok", "tool_calls": None}
 
     with patch.object(team, "_chat", side_effect=fake_chat):
         asyncio.run(team.run_team(MESSAGES, response_format=RESP_FORMAT, temperature=0.0))
-    return json.dumps(captured["synth"])
+    return json.dumps(captured["synths"])
 
 
 def test_load_prompt_returns_the_committed_file_text():
@@ -88,15 +88,14 @@ def test_synthesis_low_is_a_distinct_prompt():
     assert prompt_loader.load_prompt("synthesis-low") != prompt_loader.load_prompt("synthesis")
 
 
-def test_team_sends_the_synthesis_prompt_to_the_model():
-    # Behaviour-preservation: the team's constrained synthesis turn must carry the
-    # committed synthesis instruction — the two-section + false-premise markers AND its
-    # distinctive "Keep the prose concise." tail. Asserts on what the team SENDS (the
+def test_team_sends_the_synthesis_prompts_to_the_model():
+    # Behaviour-preservation: the team's two constrained synthesis turns must carry the
+    # committed synthesis instructions — the Answer prompt (FALSE PREMISE, DIRECT ANSWER ONLY)
+    # and the In-Depth prompt (IN-DEPTH elaboration). Asserts on what the team SENDS (the
     # seam), not the mocked return.
     blob = _run_team_capturing_synth()
     for marker in SYNTH_MARKERS:
         assert marker in blob, f"synthesis marker {marker!r} not sent to the model"
-    assert "Keep the prose concise." in blob
 
 
 def test_team_passes_through_a_schema_valid_two_section_table_envelope():

--- a/tests/test_team_config.py
+++ b/tests/test_team_config.py
@@ -25,7 +25,8 @@ def test_level_ids_advertises_the_configured_levels():
 def test_get_level_resolves_models_and_prompts():
     low = levels_loader.get_level("med-agent-team-low")
     assert low.orchestrator and low.synthesizer        # required roles present
-    assert low.synthesis_prompt == "synthesis-low"     # low's optimized synth prompt
+    # synthesis_prompt is the BASE name; two-call resolves <base>-answer / <base>-indepth.
+    assert low.synthesis_prompt == "synthesis"         # tier-agnostic two-call prompts (default base)
     high = levels_loader.get_level("med-agent-team-high")
     assert high.expert and high.expert != low.expert   # high steps up to a bigger expert
     assert high.synthesis_prompt == "synthesis"        # default prompt name
@@ -85,4 +86,5 @@ def test_run_team_routes_expert_model(monkeypatch):
     synth = [m for (m, t, rf) in calls if not t and rf]        # no-tools, rf = synthesis
     assert orch and all(m == "ORCH" for m in orch), calls
     assert expert == ["EXPERT"], calls
-    assert synth == ["SYNTH"], calls
+    # Two-call synthesis (Answer + In-Depth) — both on the synthesizer model.
+    assert synth and all(m == "SYNTH" for m in synth), calls

--- a/tests/test_team_config.py
+++ b/tests/test_team_config.py
@@ -1,35 +1,51 @@
-"""Per-request team-model selection: the OpenAI `model` id selects which model runs
-each role (orchestrator / synthesizer / expert), so ONE med-agent-hub serves any
-advertised config per request — no reboot. Advertised presets pass chartsearchai's
-exact-match served-model validation. Mocks the LM Studio boundary; exercises the
-real run_team + team_config_for. Run: pytest tests/test_team_config.py
+"""Team levels config: the OpenAI `model` id selects a level (server/levels.yaml),
+which fixes the per-role models (orchestrator / synthesizer / expert) + prompts, so
+ONE med-agent-hub serves any tier per request — no reboot. `expert: null` drops the
+medical_expert tool + role. Mocks the LM Studio boundary; exercises the real
+levels_loader + run_team. Run: pytest tests/test_team_config.py
 """
 
 import asyncio
 import json
 
-from server import team
+import pytest
+
+from server import team, levels_loader
 
 
-def test_team_config_for_maps_preset_ids():
-    from server import config as cfg
-    # med-agent-hub publishes EXACTLY three levels: low / med / high.
-    assert set(team.TEAM_PRESETS) == {"med-agent-team-low", "med-agent-team-med", "med-agent-team-high"}
-    # high: biggest synth + big expert (orchestrator stays the default e4b).
-    high = team.team_config_for("med-agent-team-high")
-    assert high["synthesizer_model"] == cfg.SYNTH_MODEL_HIGH
-    assert high["expert_model"] == cfg.EXPERT_MODEL_HIGH
-    # med: distinct mid-size synth + big expert.
-    med = team.team_config_for("med-agent-team-med")
-    assert med["synthesizer_model"] == cfg.SYNTH_MODEL_MED
-    assert med["expert_model"] == cfg.EXPERT_MODEL_MED
-    # low: small synth + small expert + an optimized synthesis prompt for that model class.
-    low = team.team_config_for("med-agent-team-low")
-    assert low["synthesizer_model"] == cfg.SYNTH_MODEL_LOW
-    assert low["expert_model"] == cfg.EXPERT_MODEL_LOW
-    assert low["synthesizer_prompt"] == "synthesis-low"
-    # an unadvertised id never crashes -> empty overrides (defaults)
-    assert team.team_config_for("med-agent-team-bogus") == {}
+def test_level_ids_advertises_the_configured_levels():
+    # med-agent-hub publishes exactly the keys in levels.yaml.
+    assert levels_loader.level_ids() == [
+        "med-agent-team-low", "med-agent-team-med", "med-agent-team-high"]
+
+
+def test_get_level_resolves_models_and_prompts():
+    low = levels_loader.get_level("med-agent-team-low")
+    assert low.orchestrator and low.synthesizer        # required roles present
+    assert low.synthesis_prompt == "synthesis-low"     # low's optimized synth prompt
+    high = levels_loader.get_level("med-agent-team-high")
+    assert high.expert and high.expert != low.expert   # high steps up to a bigger expert
+    assert high.synthesis_prompt == "synthesis"        # default prompt name
+
+
+def test_unknown_level_fails_loud():
+    with pytest.raises(KeyError):
+        levels_loader.get_level("med-agent-team-bogus")
+
+
+def test_expert_toggle_drops_the_medical_expert_tool():
+    # The whole point of the toggle: a level with no expert is offered no
+    # medical_expert tool. Red against the old hardcoded two-tool list.
+    names_with = [t["function"]["name"] for t in team._tool_definitions(has_expert=True)]
+    names_without = [t["function"]["name"] for t in team._tool_definitions(has_expert=False)]
+    assert "kb_search" in names_with and "medical_expert" in names_with
+    assert "kb_search" in names_without and "medical_expert" not in names_without
+
+
+def test_level_with_null_expert_reports_no_expert():
+    # A Level with expert unset reports has_expert False (drives the tool toggle).
+    assert levels_loader.Level(id="x", orchestrator="o", synthesizer="s", expert=None).has_expert is False
+    assert levels_loader.Level(id="y", orchestrator="o", synthesizer="s", expert="medgemma").has_expert is True
 
 
 def _stateful_fake(calls):

--- a/tests/test_team_config.py
+++ b/tests/test_team_config.py
@@ -14,9 +14,12 @@ from server import team, levels_loader
 
 
 def test_level_ids_advertises_the_configured_levels():
-    # med-agent-hub publishes exactly the keys in levels.yaml.
-    assert levels_loader.level_ids() == [
-        "med-agent-team-low", "med-agent-team-med", "med-agent-team-high"]
+    # med-agent-hub publishes the keys in levels.yaml: the core tiers are always
+    # advertised, with no duplicates (extra experiment lanes may be added over time).
+    ids = levels_loader.level_ids()
+    assert len(ids) == len(set(ids))  # no duplicate ids
+    for tier in ("med-agent-team-low", "med-agent-team-med", "med-agent-team-high"):
+        assert tier in ids, ids
 
 
 def test_get_level_resolves_models_and_prompts():

--- a/tests/test_team_roles.py
+++ b/tests/test_team_roles.py
@@ -41,8 +41,9 @@ def test_synthesis_uses_synthesizer_model_loop_uses_orchestrator(monkeypatch):
     loop_models = [m for (m, is_synth) in calls if not is_synth]
     synth_models = [m for (m, is_synth) in calls if is_synth]
     assert loop_models and all(m == "ORCH-MODEL" for m in loop_models), calls
-    assert synth_models == ["SYNTH-MODEL"], calls
-    assert json.loads(out)["answer"] == "ok"
+    # Two-call synthesis (Answer + In-Depth) — both run on the synthesizer model.
+    assert synth_models and all(m == "SYNTH-MODEL" for m in synth_models), calls
+    assert "ok" in json.loads(out)["answer"]
 
 
 def test_synthesis_applies_anti_degeneration_params(monkeypatch):
@@ -89,7 +90,7 @@ def test_synthesis_reads_reasoning_content_when_content_empty(monkeypatch):
         _MESSAGES, response_format=_RF,
         orchestrator_model="ORCH-MODEL", synthesizer_model="SYNTH-MODEL",
     ))
-    assert json.loads(out)["answer"] == "qwen-ok", out
+    assert "qwen-ok" in json.loads(out)["answer"], out
 
 
 def test_synthesis_normalizes_literal_newline_and_reconciles_citations(monkeypatch):

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,0 +1,82 @@
+"""Deterministic temporal grounding (P0 anchor + P1 series), computed server-side from the chart
+text so the synth REPORTS dated facts instead of deriving them. Pure-function unit tests — no LLM.
+
+Grounded in the real Aloice chart format (chartsearchai PatientChartSerializer):
+  [N] (YYYY-MM-DD) <Class> — <concept>: <value> <unit>
+Run: pytest tests/test_temporal.py
+"""
+
+from server import temporal
+
+# A realistic slice of the serialized chart (most-recent-first, like the real snapshot).
+_CHART = """Patient records (most recent first):
+Patient: 41-year-old Male
+
+[15] (2006-05-18) Finding — Weight (kg), WT): 41.0 kg
+[47] (2006-05-11) Finding — Weight (kg), WT): 42.0 kg
+[79] (2006-04-26) Finding — Weight (kg), WT): 48.0 kg
+[97] (2006-04-24) Test — Haemoglobin: 3.9 g/dL
+[186] (2006-03-06) Test — Haemoglobin: 9.1 g/dL
+[202] (2006-03-03) Finding — Weight (kg), WT): 52.0 kg
+[218] (2006-03-02) Test — CD4 count: 72.0 cells/uL
+[26] (2006-05-18) Drug order: Lamivudine / zidovudine. Action: NEW. Urgency: ROUTINE
+[1] (2006-05-18) Assessment — Scheduled visit: No
+[5] (2006-05-11) Assessment — Return visit date: 2006-05-18
+"""
+
+
+# ---- resolve_anchor ---------------------------------------------------------
+
+def test_resolve_anchor_latest_record_picks_max_date():
+    assert temporal.resolve_anchor("latest_record", _CHART) == "2006-05-18"
+    assert temporal.resolve_anchor(None, _CHART) == "2006-05-18"  # default = latest_record
+
+
+def test_resolve_anchor_explicit_date_passthrough():
+    assert temporal.resolve_anchor("2006-06-01", _CHART) == "2006-06-01"
+
+
+def test_resolve_anchor_latest_record_no_dates_is_none():
+    assert temporal.resolve_anchor("latest_record", "no dates here") is None
+
+
+# ---- parse_dated_observations ----------------------------------------------
+
+def test_parse_extracts_numeric_obs_only():
+    obs = temporal.parse_dated_observations(_CHART)
+    concepts = {o["concept"] for o in obs}
+    # numeric series present; non-numeric (drug order, Yes/No assessment) excluded
+    assert "Weight" in concepts and "Haemoglobin" in concepts and "CD4 count" in concepts
+    assert not any("Scheduled visit" in c or "Lamivudine" in c for c in concepts)
+    assert "Return visit date" not in concepts  # date-valued obs is not a numeric series
+    weights = sorted((o for o in obs if o["concept"] == "Weight"), key=lambda o: o["date"])
+    assert [w["value"] for w in weights] == [52.0, 48.0, 42.0, 41.0]  # sorted ascending, deduped per date
+    assert weights[0]["unit"] == "kg"
+
+
+# ---- build_temporal_block ---------------------------------------------------
+
+def test_block_carries_anchor_and_correct_recency_and_trend():
+    block = temporal.build_temporal_block(_CHART, "2006-05-18")
+    # the explicit reference-date anchor line
+    assert "2006-05-18" in block
+    assert "recent" in block.lower()  # tells the model how to read "now"/"most recent"
+    # haemoglobin most-recent is 3.9 (2006-04-24), NOT the older 9.1 (the ordering bug P1 fixes)
+    hgb_line = next(l for l in block.splitlines() if "Haemoglobin" in l)
+    assert "3.9" in hgb_line
+    assert hgb_line.index("3.9") < (hgb_line.index("9.1") if "9.1" in hgb_line else len(hgb_line))
+    # weight is a real downward trend 52 -> 41
+    wt_line = next(l for l in block.splitlines() if "Weight" in l)
+    assert "52" in wt_line and "41.0" in wt_line
+
+
+def test_block_single_point_makes_no_trend_claim():
+    block = temporal.build_temporal_block(_CHART, "2006-05-18")
+    cd4_line = next(l for l in block.splitlines() if "CD4 count" in l)
+    # one CD4 point -> report the value, never a trend/direction (the <2-points guard)
+    assert "72" in cd4_line
+    assert "↑" not in cd4_line and "↓" not in cd4_line and "trend" not in cd4_line.lower()
+
+
+def test_block_empty_without_anchor_or_series():
+    assert temporal.build_temporal_block("no dates", None) == ""

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,16 +1,16 @@
-"""Two-call generation + two independent validators. From generation onward the **Answer**
-and the **In Depth** are DISTINCT: a separate Answer synthesis (bound to chartsearchai's
-{answer, citations, blocks} schema) and a separate In-Depth synthesis (a list of claim strings),
-each audited by its own validator, combined into one markdown body ("**Answer**\\n...\\n\\n**In
-Depth**\\n- ...") only at the chartsearchai handoff.
+"""Two-call generation + two independent validators, each with a re-synth cycle that yields a
+per-section CONFIDENCE label (green / yellow / red). The Answer and the In-Depth are distinct from
+generation onward and combined into one body only at the chartsearchai handoff.
 
-  ANSWER (strict): a flagged-with-a-reason Answer -> re-synthesize, else ABSTAIN the turn.
-  IN DEPTH (advisory, claim-level): drop exactly the claims the validator flags; never abstains.
+  Confidence (per section): green = passed review first pass; yellow = flagged -> re-synthesized ->
+  cleared; red = flagged -> re-synthesized -> still flagged. We ALWAYS ship the answer — a red
+  section ships WITH its criticism (never hidden; the renderer decides visibility). A reasonless
+  Answer flag (answer_ok=False, empty issues) is treated as PASS (noise guard). The structured
+  confidence rides the envelope `confidence` field AND the reasoning trace.
 
-Mocks only the LM Studio boundary (`_chat`) and exercises the real run_team end-to-end (asserting
-the final combined answer string). The mock branches on the response_format json_schema name so the
-four distinct call sites (chart_answer synth, in_depth synth, answer_verdict, indepth_verdict) are
-served independently — exactly how the production code distinguishes them.
+Mocks only the LM Studio boundary (`_chat`) and exercises the real run_team end-to-end. The mock
+branches on the response_format json_schema name so the four call sites (chart_answer synth, in_depth
+synth, answer_verdict, indepth_verdict) are served independently.
 Run: pytest tests/test_validator.py
 """
 
@@ -24,24 +24,18 @@ _MESSAGES = [
     {"role": "user", "content": "patient chart"},
     {"role": "user", "content": "the question"},
 ]
-# chartsearchai's envelope response_format; its json_schema name is what the Answer synth call
-# carries, so the mock recognizes that call site by this name.
 _RF = {"type": "json_schema", "json_schema": {"name": "chart_answer"}}
 
 
-def _factory(calls, verdicts):
-    """Mock _chat that branches on the response_format json_schema name, mirroring the four
-    distinct call sites in team.run_team:
-
-      "chart_answer"   (Answer synthesis)   -> a versioned {answer, citations, blocks} envelope;
-      "in_depth"       (In-Depth synthesis) -> two versioned claim strings;
-      "answer_verdict" (Answer validator)   -> {answer_ok, answer_issues} pulled from `verdicts`;
-      "indepth_verdict"(In-Depth validator) -> {drop} pulled from `verdicts`;
-      no response_format (orchestrator loop) -> no tools, no content (break to synthesis).
-
-    `verdicts` is the per-Answer-audit-attempt list; the In-Depth `drop` is read from the FIRST
-    verdict (the In-Depth validator runs once)."""
-    state = {"answer_synth": 0, "indepth_synth": 0, "answer_val": 0}
+def _factory(calls, verdicts, iv_drops=None):
+    """Mock _chat. Branches on the response_format json_schema name:
+      "chart_answer"    (Answer synth)      -> {answer: ans-vN, ...} (N = answer-synth call index);
+      "in_depth"        (In-Depth synth)    -> {claims: [claim-A-vN, claim-B-vN]};
+      "answer_verdict"  (Answer validator)  -> the Nth entry of `verdicts` ({answer_ok, answer_issues});
+      "indepth_verdict" (In-Depth validator)-> {drop} = the Nth entry of `iv_drops` (a list of drop-
+                          lists per In-Depth audit attempt); falls back to verdicts[0].drop / [].
+      no response_format (orchestrator)     -> no tools (break to synthesis)."""
+    state = {"answer_synth": 0, "indepth_synth": 0, "answer_val": 0, "iv": 0}
 
     async def fake_chat(client, model, messages, *, tools=None, response_format=None,
                         temperature=None, max_tokens=None, repeat_penalty=None,
@@ -49,138 +43,148 @@ def _factory(calls, verdicts):
         name = (response_format or {}).get("json_schema", {}).get("name")
         calls.append((model, name))
 
-        if name == "chart_answer":  # Answer synthesis (chartsearchai envelope schema)
-            n = state["answer_synth"]
-            state["answer_synth"] += 1
-            return {"content": json.dumps({
-                "answer": f"ans-v{n}", "citations": [], "blocks": []})}
+        if name == "chart_answer":
+            n = state["answer_synth"]; state["answer_synth"] += 1
+            return {"content": json.dumps({"answer": f"ans-v{n}", "citations": [], "blocks": []})}
 
-        if name == "in_depth":  # In-Depth synthesis (claim list)
-            n = state["indepth_synth"]
-            state["indepth_synth"] += 1
-            return {"content": json.dumps({
-                "claims": [f"claim-A-v{n}", f"claim-B-v{n}"]})}
+        if name == "in_depth":
+            n = state["indepth_synth"]; state["indepth_synth"] += 1
+            return {"content": json.dumps({"claims": [f"claim-A-v{n}", f"claim-B-v{n}"]})}
 
-        if name == "answer_verdict":  # Answer validator
-            v = verdicts[min(state["answer_val"], len(verdicts) - 1)]
+        if name == "answer_verdict":
+            v = verdicts[min(state["answer_val"], len(verdicts) - 1)] if verdicts else {"answer_ok": True}
             state["answer_val"] += 1
             return {"content": json.dumps({
                 "answer_ok": v["answer_ok"], "answer_issues": v.get("answer_issues", "")})}
 
-        if name == "indepth_verdict":  # In-Depth validator
-            drop = verdicts[0].get("drop", []) if verdicts else []
-            return {"content": json.dumps({"drop": drop, "issues": ""})}
+        if name == "indepth_verdict":
+            if iv_drops is not None:
+                d = iv_drops[min(state["iv"], len(iv_drops) - 1)]
+            else:
+                d = (verdicts[0].get("drop", []) if verdicts else [])
+            state["iv"] += 1
+            return {"content": json.dumps({"drop": d, "issues": "flagged" if d else ""})}
 
-        return {"content": "", "tool_calls": None}  # orchestrator loop turn
+        return {"content": "", "tool_calls": None}
 
     return fake_chat
 
 
 def _counts(calls):
-    answer_synth = sum(1 for _m, n in calls if n == "chart_answer")
-    indepth_synth = sum(1 for _m, n in calls if n == "in_depth")
-    answer_val = sum(1 for _m, n in calls if n == "answer_verdict")
-    indepth_val = sum(1 for _m, n in calls if n == "indepth_verdict")
-    return answer_synth, indepth_synth, answer_val, indepth_val
+    return (sum(1 for _m, n in calls if n == "chart_answer"),
+            sum(1 for _m, n in calls if n == "in_depth"),
+            sum(1 for _m, n in calls if n == "answer_verdict"),
+            sum(1 for _m, n in calls if n == "indepth_verdict"))
 
 
-def _run(verdicts, **kw):
+def _run(verdicts, iv_drops=None, **kw):
+    """Run a turn; return (calls, parsed_envelope)."""
     calls = []
-    team._chat = _factory(calls, verdicts)
+    team._chat = _factory(calls, verdicts, iv_drops)
     out = asyncio.run(team.run_team(
         _MESSAGES, response_format=_RF, orchestrator_model="ORCH",
         synthesizer_model="SYNTH", validator_model="VALIDATOR", **kw))
-    return calls, json.loads(out)["answer"]
+    return calls, json.loads(out)
 
 
 def test_no_validator_ships_answer_and_both_claims(monkeypatch):
-    """No validator -> ship the Answer + both In-Depth claim bullets, no audit calls."""
     calls = []
     monkeypatch.setattr(team, "_chat", _factory(calls, []))
-    out = asyncio.run(team.run_team(
-        _MESSAGES, response_format=_RF, orchestrator_model="ORCH", synthesizer_model="SYNTH"))
-    ans = json.loads(out)["answer"]
-    assert "**Answer**" in ans and "ans-v0" in ans
-    assert "claim-A-v0" in ans and "claim-B-v0" in ans
+    env = json.loads(asyncio.run(team.run_team(
+        _MESSAGES, response_format=_RF, orchestrator_model="ORCH", synthesizer_model="SYNTH")))
+    ans = env["answer"]
+    assert "ans-v0" in ans and "claim-A-v0" in ans and "claim-B-v0" in ans
     _as, _is, av, iv = _counts(calls)
-    assert av == 0 and iv == 0, calls  # no validator was configured
+    assert av == 0 and iv == 0, calls
 
 
-def test_both_clean_ships_full_body():
-    """Both validators pass -> FULL combined body: **Answer** + both In-Depth claims."""
-    calls, ans = _run([{"answer_ok": True, "drop": []}])
-    answer_synth, indepth_synth, answer_val, indepth_val = _counts(calls)
-    assert answer_synth == 1 and indepth_synth == 1, calls
-    assert answer_val == 1 and indepth_val == 1, calls
-    assert "**Answer**" in ans and "ans-v0" in ans
-    assert "**In Depth**" in ans
-    assert "claim-A-v0" in ans and "claim-B-v0" in ans
+# ---- ANSWER confidence -----------------------------------------------------
+
+def test_answer_green_clean_first_pass():
+    calls, env = _run([{"answer_ok": True, "drop": []}])
+    assert env["confidence"]["answer"]["level"] == "green"
+    assert "🔴" not in env["answer"] and "🟡" not in env["answer"]
+    assert "ans-v0" in env["answer"] and "claim-A-v0" in env["answer"]
 
 
-def test_indepth_drop_strips_only_flagged_claim_no_resynth():
-    """In-Depth drop=[2]: keep the Answer + claim-A, strip claim-B. NOT an abstain, and the
-    In-Depth synth runs ONCE (the Answer is never re-synthesized for an In-Depth drop)."""
-    calls, ans = _run([{"answer_ok": True, "drop": [2]}])
-    answer_synth, indepth_synth, answer_val, indepth_val = _counts(calls)
-    assert answer_synth == 1, calls          # Answer synthesized once (no re-synth)
-    assert indepth_synth == 1, calls         # In-Depth synthesized once
-    assert answer_val == 1 and indepth_val == 1, calls
-    assert "ans-v0" in ans                    # Answer kept
-    assert "claim-A-v0" in ans               # claim #1 kept
-    assert "claim-B-v0" not in ans           # claim #2 dropped
-    assert "could not produce" not in ans.lower()  # NOT an abstain
-
-
-def test_answer_flagged_with_reason_resynth_fixes_adopts_v1():
-    """ANSWER path: flagged WITH a reason -> re-synthesize -> now ok -> adopt the revision (v1)."""
-    calls, ans = _run([{"answer_ok": False, "answer_issues": "wrong dose"},
+def test_answer_yellow_fixed_on_retry_shows_message():
+    """Flagged with a reason -> re-synth -> cleared -> yellow, the corrected answer (v1) is shown."""
+    calls, env = _run([{"answer_ok": False, "answer_issues": "wrong dose"},
                        {"answer_ok": True}], validator_max_loops=1)
-    answer_synth, indepth_synth, answer_val, indepth_val = _counts(calls)
-    assert answer_synth == 2 and answer_val == 2, calls  # re-synth + re-audit
-    assert "ans-v1" in ans                                # adopted the revision
-    assert indepth_synth == 1, calls                      # In-Depth still runs once afterward
+    a_synth, _i, a_val, _iv = _counts(calls)
+    assert a_synth == 2 and a_val == 2, calls
+    assert env["confidence"]["answer"]["level"] == "yellow"
+    assert "ans-v1" in env["answer"]                 # the corrected answer is presented
+    assert "🟡" in env["answer"]                       # yellow caveat in the body fallback
 
 
-def test_answer_flagged_with_reason_persists_abstains_gracefully():
-    """ANSWER path: flagged WITH a reason and STILL flagged -> GRACEFUL abstain: a nuanced message
-    that surfaces what the review found (answer_issues), AND the In-Depth KB context is still shipped."""
-    calls, ans = _run([{"answer_ok": False, "answer_issues": "wrong dose"},
+def test_answer_red_presents_flagged_answer_with_caveat():
+    """Flagged + still flagged after re-synth -> RED: present the (last) answer + the criticism note,
+    NOT hidden, and structured confidence=red carrying the reviewer's reason."""
+    calls, env = _run([{"answer_ok": False, "answer_issues": "wrong dose"},
                        {"answer_ok": False, "answer_issues": "still wrong"}], validator_max_loops=1)
-    answer_synth, indepth_synth, answer_val, indepth_val = _counts(calls)
-    assert answer_synth == 2 and answer_val == 2, calls
-    assert "could not confirm" in ans.lower()             # graceful abstain (nuanced wording)
-    assert "still wrong" in ans                           # surfaces the specific review finding
-    assert "ans-v" not in ans                             # the flagged draft answer is NOT shipped
-    assert indepth_synth == 1, calls                      # In-Depth KB context IS still generated
-    assert "claim-A-v0" in ans                            # ...and shipped alongside the abstain
+    a_synth, i_synth, a_val, _iv = _counts(calls)
+    assert a_synth == 2 and a_val == 2, calls
+    assert env["confidence"]["answer"]["level"] == "red"
+    assert "still wrong" in env["confidence"]["answer"]["note"]   # criticism surfaced
+    assert "ans-v1" in env["answer"]                              # the answer IS presented (not hidden)
+    assert "🔴" in env["answer"]
+    assert i_synth >= 1                                           # In-Depth still generated
 
 
-def test_answer_flagged_without_reason_ships_noise_guard():
-    """NOISE GUARD: answer_ok=False with EMPTY answer_issues is a reasonless flag -> treat as PASS,
-    ship the answer (NOT an abstain), and do not re-synthesize."""
-    calls, ans = _run([{"answer_ok": False, "answer_issues": ""}])
-    answer_synth, indepth_synth, answer_val, indepth_val = _counts(calls)
-    assert answer_synth == 1 and answer_val == 1, calls   # single synth + single audit, no re-synth
-    assert "ans-v0" in ans                                # shipped the answer
-    assert "could not produce" not in ans.lower()         # NOT an abstain
-    assert "claim-A-v0" in ans                            # In-Depth still flows through
+def test_answer_noise_flag_stays_green():
+    """answer_ok=False with EMPTY answer_issues is reasonless noise -> PASS -> green, no re-synth."""
+    calls, env = _run([{"answer_ok": False, "answer_issues": "", "drop": []}])
+    a_synth, _i, a_val, _iv = _counts(calls)
+    assert a_synth == 1 and a_val == 1, calls
+    assert env["confidence"]["answer"]["level"] == "green"
+    assert "ans-v0" in env["answer"]
 
 
-def test_reasoning_trace_is_written_with_steps_and_disposition(tmp_path, monkeypatch):
-    """The hub appends a per-turn reasoning trace: the ordered steps (answer_synth, answer_validator,
-    indepth_synth, indepth_validator) + the disposition + the level_id correlation key."""
+# ---- IN-DEPTH confidence (re-synth before strip) ---------------------------
+
+def test_indepth_green_no_drop():
+    calls, env = _run([{"answer_ok": True, "drop": []}])
+    assert env["confidence"]["in_depth"]["level"] == "green"
+    assert "claim-A-v0" in env["answer"] and "claim-B-v0" in env["answer"]
+
+
+def test_indepth_yellow_resynth_clears_drop():
+    """In-Depth flagged on first audit -> re-synth -> clean -> yellow, the REVISED claims (v1) ship."""
+    calls, env = _run([{"answer_ok": True}], iv_drops=[[2], []])
+    _a, i_synth, _av, i_val = _counts(calls)
+    assert i_synth == 2 and i_val == 2, calls          # synth + re-synth, two audits
+    assert env["confidence"]["in_depth"]["level"] == "yellow"
+    assert "claim-A-v1" in env["answer"]               # revised claims adopted
+
+
+def test_indepth_red_strips_after_failed_resynth():
+    """In-Depth flagged -> re-synth -> STILL flagged -> red: strip the still-flagged claim, keep rest."""
+    calls, env = _run([{"answer_ok": True}], iv_drops=[[2], [2]])
+    _a, i_synth, _av, i_val = _counts(calls)
+    assert i_synth == 2 and i_val == 2, calls
+    assert env["confidence"]["in_depth"]["level"] == "red"
+    assert "claim-A-v1" in env["answer"]               # surviving claim kept
+    assert "claim-B-v1" not in env["answer"]           # still-flagged claim stripped
+
+
+# ---- trace package ---------------------------------------------------------
+
+def test_trace_carries_structured_package(tmp_path, monkeypatch):
+    """The hub writes the structured package: shipped answer_text + in_depth_claims + per-section
+    confidence + ordered steps, keyed by level_id (the dashboard's render + correlation source)."""
     monkeypatch.setattr(team, "_TRACE_DIR", str(tmp_path))
     calls = []
     monkeypatch.setattr(team, "_chat", _factory(calls, [{"answer_ok": True, "drop": []}]))
     asyncio.run(team.run_team(
         _MESSAGES, response_format=_RF, orchestrator_model="ORCH", synthesizer_model="SYNTH",
         validator_model="VALIDATOR", level_id="med-agent-team-low-validated"))
-    lines = (tmp_path / "trace.jsonl").read_text().splitlines()
-    assert len(lines) == 1, lines
-    entry = json.loads(lines[0])
+    entry = json.loads((tmp_path / "trace.jsonl").read_text().splitlines()[0])
     assert entry["level_id"] == "med-agent-team-low-validated"
-    assert entry["disposition"] == "full"
+    assert entry["answer_confidence"]["level"] == "green"
+    assert entry["indepth_confidence"]["level"] == "green"
+    assert "ans-v0" in entry["answer_text"]
+    assert entry["in_depth_claims"] and "claim-A-v0" in entry["in_depth_claims"][0]
     roles = [s["role"] for s in entry["steps"]]
     assert "answer_synth" in roles and "answer_validator" in roles
     assert "indepth_synth" in roles and "indepth_validator" in roles
-    assert entry["ts"] and entry["models"]["synthesizer"] == "SYNTH"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,8 +1,16 @@
-"""Validator role: an optional post-synthesis audit that drives TWO INDEPENDENT remediation
-paths — the **Answer** (strict: re-synthesize, else abstain) and the **In Depth** (advisory,
-claim-level: block/strip exactly the claims the validator flags, Answer untouched, never abstain).
-The In Depth is emitted as an enumerated claim list so each claim is individually addressable.
-Mocks the LM Studio boundary (`_chat`) and exercises the real run_team.
+"""Two-call generation + two independent validators. From generation onward the **Answer**
+and the **In Depth** are DISTINCT: a separate Answer synthesis (bound to chartsearchai's
+{answer, citations, blocks} schema) and a separate In-Depth synthesis (a list of claim strings),
+each audited by its own validator, combined into one markdown body ("**Answer**\\n...\\n\\n**In
+Depth**\\n- ...") only at the chartsearchai handoff.
+
+  ANSWER (strict): a flagged-with-a-reason Answer -> re-synthesize, else ABSTAIN the turn.
+  IN DEPTH (advisory, claim-level): drop exactly the claims the validator flags; never abstains.
+
+Mocks only the LM Studio boundary (`_chat`) and exercises the real run_team end-to-end (asserting
+the final combined answer string). The mock branches on the response_format json_schema name so the
+four distinct call sites (chart_answer synth, in_depth synth, answer_verdict, indepth_verdict) are
+served independently — exactly how the production code distinguishes them.
 Run: pytest tests/test_validator.py
 """
 
@@ -16,130 +24,139 @@ _MESSAGES = [
     {"role": "user", "content": "patient chart"},
     {"role": "user", "content": "the question"},
 ]
+# chartsearchai's envelope response_format; its json_schema name is what the Answer synth call
+# carries, so the mock recognizes that call site by this name.
 _RF = {"type": "json_schema", "json_schema": {"name": "chart_answer"}}
 
 
 def _factory(calls, verdicts):
-    """Mock _chat. Orchestrator loop -> no tools (break to synth). Synth -> a versioned envelope
-    whose answer has an **Answer** + a two-bullet **In Depth**. Validator -> a verdict
-    {answer_ok, indepth_drop} pulled from `verdicts` (the real _run_validator clamps the drop)."""
-    state = {"synth": 0, "val": 0}
+    """Mock _chat that branches on the response_format json_schema name, mirroring the four
+    distinct call sites in team.run_team:
+
+      "chart_answer"   (Answer synthesis)   -> a versioned {answer, citations, blocks} envelope;
+      "in_depth"       (In-Depth synthesis) -> two versioned claim strings;
+      "answer_verdict" (Answer validator)   -> {answer_ok, answer_issues} pulled from `verdicts`;
+      "indepth_verdict"(In-Depth validator) -> {drop} pulled from `verdicts`;
+      no response_format (orchestrator loop) -> no tools, no content (break to synthesis).
+
+    `verdicts` is the per-Answer-audit-attempt list; the In-Depth `drop` is read from the FIRST
+    verdict (the In-Depth validator runs once)."""
+    state = {"answer_synth": 0, "indepth_synth": 0, "answer_val": 0}
 
     async def fake_chat(client, model, messages, *, tools=None, response_format=None,
                         temperature=None, max_tokens=None, repeat_penalty=None,
                         dry_multiplier=None, **kwargs):
         name = (response_format or {}).get("json_schema", {}).get("name")
         calls.append((model, name))
-        if name == "validator_verdict":
-            v = verdicts[min(state["val"], len(verdicts) - 1)]
-            state["val"] += 1
+
+        if name == "chart_answer":  # Answer synthesis (chartsearchai envelope schema)
+            n = state["answer_synth"]
+            state["answer_synth"] += 1
             return {"content": json.dumps({
-                "answer_ok": v["answer_ok"], "answer_issues": "" if v["answer_ok"] else "wrong value",
-                "indepth_drop": v.get("indepth_drop", []), "indepth_issues": ""})}
-        if response_format is not None:  # synthesis (chart_answer schema)
-            n = state["synth"]
-            state["synth"] += 1
+                "answer": f"ans-v{n}", "citations": [], "blocks": []})}
+
+        if name == "in_depth":  # In-Depth synthesis (claim list)
+            n = state["indepth_synth"]
+            state["indepth_synth"] += 1
             return {"content": json.dumps({
-                "answer": f"**Answer** ans-v{n}\n\n**In Depth**\n- claim-A-v{n} [1]\n- claim-B-v{n} per WHO",
-                "citations": [], "blocks": []})}
-        return {"content": "", "tool_calls": None}  # loop turn
+                "claims": [f"claim-A-v{n}", f"claim-B-v{n}"]})}
+
+        if name == "answer_verdict":  # Answer validator
+            v = verdicts[min(state["answer_val"], len(verdicts) - 1)]
+            state["answer_val"] += 1
+            return {"content": json.dumps({
+                "answer_ok": v["answer_ok"], "answer_issues": v.get("answer_issues", "")})}
+
+        if name == "indepth_verdict":  # In-Depth validator
+            drop = verdicts[0].get("drop", []) if verdicts else []
+            return {"content": json.dumps({"drop": drop, "issues": ""})}
+
+        return {"content": "", "tool_calls": None}  # orchestrator loop turn
 
     return fake_chat
 
 
 def _counts(calls):
-    val = sum(1 for m, n in calls if n == "validator_verdict")
-    synth = sum(1 for m, n in calls if n == "chart_answer")
-    return val, synth
+    answer_synth = sum(1 for _m, n in calls if n == "chart_answer")
+    indepth_synth = sum(1 for _m, n in calls if n == "in_depth")
+    answer_val = sum(1 for _m, n in calls if n == "answer_verdict")
+    indepth_val = sum(1 for _m, n in calls if n == "indepth_verdict")
+    return answer_synth, indepth_synth, answer_val, indepth_val
 
 
 def _run(verdicts, **kw):
     calls = []
-    monkey = team
-    monkey._chat = _factory(calls, verdicts)
+    team._chat = _factory(calls, verdicts)
     out = asyncio.run(team.run_team(
         _MESSAGES, response_format=_RF, orchestrator_model="ORCH",
         synthesizer_model="SYNTH", validator_model="VALIDATOR", **kw))
     return calls, json.loads(out)["answer"]
 
 
-# ---- pure helpers (claim addressability) -----------------------------------
-
-def test_split_answer_indepth_parses_bullets():
-    ans = "**Answer** the answer [3]\n\n**In Depth**\n- first claim [3]\n- second claim per WHO"
-    answer_part, claims = team._split_answer_indepth(ans)
-    assert "the answer" in answer_part and "**In Depth**" not in answer_part
-    assert claims == ["first claim [3]", "second claim per WHO"]
-
-
-def test_split_answer_indepth_no_section():
-    answer_part, claims = team._split_answer_indepth("**Answer** not documented.")
-    assert claims == []
-
-
-def test_strip_indepth_claims_removes_only_flagged():
-    env = json.dumps({"answer": "**Answer** A\n\n**In Depth**\n- keep me\n- drop me\n- keep me too",
-                      "citations": [], "blocks": []})
-    out = json.loads(team._strip_indepth_claims(env, [2]))["answer"]
-    assert "keep me" in out and "keep me too" in out
-    assert "drop me" not in out          # the flagged claim is gone
-    assert "**Answer** A" in out         # the Answer is untouched
+def test_no_validator_ships_answer_and_both_claims(monkeypatch):
+    """No validator -> ship the Answer + both In-Depth claim bullets, no audit calls."""
+    calls = []
+    monkeypatch.setattr(team, "_chat", _factory(calls, []))
+    out = asyncio.run(team.run_team(
+        _MESSAGES, response_format=_RF, orchestrator_model="ORCH", synthesizer_model="SYNTH"))
+    ans = json.loads(out)["answer"]
+    assert "**Answer**" in ans and "ans-v0" in ans
+    assert "claim-A-v0" in ans and "claim-B-v0" in ans
+    _as, _is, av, iv = _counts(calls)
+    assert av == 0 and iv == 0, calls  # no validator was configured
 
 
-def test_strip_all_claims_keeps_answer_with_note():
-    env = json.dumps({"answer": "**Answer** A\n\n**In Depth**\n- one\n- two", "citations": [], "blocks": []})
-    out = json.loads(team._strip_indepth_claims(env, [1, 2]))["answer"]
-    assert "**Answer** A" in out and "one" not in out and "two" not in out
-    assert "withheld" in out.lower()
+def test_both_clean_ships_full_body():
+    """Both validators pass -> FULL combined body: **Answer** + both In-Depth claims."""
+    calls, ans = _run([{"answer_ok": True, "drop": []}])
+    answer_synth, indepth_synth, answer_val, indepth_val = _counts(calls)
+    assert answer_synth == 1 and indepth_synth == 1, calls
+    assert answer_val == 1 and indepth_val == 1, calls
+    assert "**Answer**" in ans and "ans-v0" in ans
+    assert "**In Depth**" in ans
+    assert "claim-A-v0" in ans and "claim-B-v0" in ans
 
 
-# ---- end-to-end through run_team --------------------------------------------
-
-def test_validator_none_skips_audit(monkeypatch):
-    monkeypatch.setattr(team, "_chat", _factory([], []))
-    out = asyncio.run(team.run_team(_MESSAGES, response_format=_RF,
-                                    orchestrator_model="ORCH", synthesizer_model="SYNTH"))
-    assert "ans-v0" in json.loads(out)["answer"]
-
-
-def test_validator_both_clean_ships_full():
-    calls, ans = _run([{"answer_ok": True, "indepth_drop": []}])
-    val, synth = _counts(calls)
-    assert val == 1 and synth == 1, calls
-    assert "ans-v0" in ans and "claim-A-v0" in ans and "claim-B-v0" in ans
+def test_indepth_drop_strips_only_flagged_claim_no_resynth():
+    """In-Depth drop=[2]: keep the Answer + claim-A, strip claim-B. NOT an abstain, and the
+    In-Depth synth runs ONCE (the Answer is never re-synthesized for an In-Depth drop)."""
+    calls, ans = _run([{"answer_ok": True, "drop": [2]}])
+    answer_synth, indepth_synth, answer_val, indepth_val = _counts(calls)
+    assert answer_synth == 1, calls          # Answer synthesized once (no re-synth)
+    assert indepth_synth == 1, calls         # In-Depth synthesized once
+    assert answer_val == 1 and indepth_val == 1, calls
+    assert "ans-v0" in ans                    # Answer kept
+    assert "claim-A-v0" in ans               # claim #1 kept
+    assert "claim-B-v0" not in ans           # claim #2 dropped
+    assert "could not produce" not in ans.lower()  # NOT an abstain
 
 
-def test_validator_indepth_claim_stripped_keeps_answer():
-    """GRANULAR claim-level: drop claim #2 only — keep the Answer + claim #1, no re-synth, no abstain."""
-    calls, ans = _run([{"answer_ok": True, "indepth_drop": [2]}])
-    val, synth = _counts(calls)
-    assert val == 1 and synth == 1, calls       # audited once, NOT re-synthesized
-    assert "ans-v0" in ans                       # Answer kept
-    assert "claim-A-v0" in ans                   # claim #1 kept
-    assert "claim-B-v0" not in ans               # claim #2 stripped
-    assert "could not produce" not in ans.lower()  # NOT a full abstain
+def test_answer_flagged_with_reason_resynth_fixes_adopts_v1():
+    """ANSWER path: flagged WITH a reason -> re-synthesize -> now ok -> adopt the revision (v1)."""
+    calls, ans = _run([{"answer_ok": False, "answer_issues": "wrong dose"},
+                       {"answer_ok": True}], validator_max_loops=1)
+    answer_synth, indepth_synth, answer_val, indepth_val = _counts(calls)
+    assert answer_synth == 2 and answer_val == 2, calls  # re-synth + re-audit
+    assert "ans-v1" in ans                                # adopted the revision
+    assert indepth_synth == 1, calls                      # In-Depth still runs once afterward
 
 
-def test_validator_all_indepth_dropped_keeps_answer():
-    calls, ans = _run([{"answer_ok": True, "indepth_drop": [1, 2]}])
-    val, synth = _counts(calls)
-    assert val == 1 and synth == 1, calls
-    assert "ans-v0" in ans and "claim-A-v0" not in ans and "claim-B-v0" not in ans
-    assert "could not produce" not in ans.lower()  # In-Depth wipe never abstains the turn
+def test_answer_flagged_with_reason_persists_abstains():
+    """ANSWER path: flagged WITH a reason and STILL flagged after the fix -> abstain the turn."""
+    calls, ans = _run([{"answer_ok": False, "answer_issues": "wrong dose"},
+                       {"answer_ok": False, "answer_issues": "still wrong"}], validator_max_loops=1)
+    answer_synth, indepth_synth, answer_val, indepth_val = _counts(calls)
+    assert answer_synth == 2 and answer_val == 2, calls
+    assert "could not produce" in ans.lower()             # abstained
+    assert indepth_synth == 0, calls                      # no In-Depth on an abstained turn
 
 
-def test_validator_answer_flagged_resynth_fixes():
-    """ANSWER path is independent: flagged Answer -> re-synthesize -> now ok -> adopt."""
-    calls, ans = _run([{"answer_ok": False, "indepth_drop": []},
-                       {"answer_ok": True, "indepth_drop": []}], validator_max_loops=1)
-    val, synth = _counts(calls)
-    assert val == 2 and synth == 2, calls
-    assert "ans-v1" in ans
-
-
-def test_validator_answer_flagged_persists_abstains():
-    calls, ans = _run([{"answer_ok": False, "indepth_drop": []},
-                       {"answer_ok": False, "indepth_drop": []}], validator_max_loops=1)
-    val, synth = _counts(calls)
-    assert val == 2 and synth == 2, calls
-    assert "could not produce" in ans.lower()
+def test_answer_flagged_without_reason_ships_noise_guard():
+    """NOISE GUARD: answer_ok=False with EMPTY answer_issues is a reasonless flag -> treat as PASS,
+    ship the answer (NOT an abstain), and do not re-synthesize."""
+    calls, ans = _run([{"answer_ok": False, "answer_issues": ""}])
+    answer_synth, indepth_synth, answer_val, indepth_val = _counts(calls)
+    assert answer_synth == 1 and answer_val == 1, calls   # single synth + single audit, no re-synth
+    assert "ans-v0" in ans                                # shipped the answer
+    assert "could not produce" not in ans.lower()         # NOT an abstain
+    assert "claim-A-v0" in ans                            # In-Depth still flows through

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -141,14 +141,18 @@ def test_answer_flagged_with_reason_resynth_fixes_adopts_v1():
     assert indepth_synth == 1, calls                      # In-Depth still runs once afterward
 
 
-def test_answer_flagged_with_reason_persists_abstains():
-    """ANSWER path: flagged WITH a reason and STILL flagged after the fix -> abstain the turn."""
+def test_answer_flagged_with_reason_persists_abstains_gracefully():
+    """ANSWER path: flagged WITH a reason and STILL flagged -> GRACEFUL abstain: a nuanced message
+    that surfaces what the review found (answer_issues), AND the In-Depth KB context is still shipped."""
     calls, ans = _run([{"answer_ok": False, "answer_issues": "wrong dose"},
                        {"answer_ok": False, "answer_issues": "still wrong"}], validator_max_loops=1)
     answer_synth, indepth_synth, answer_val, indepth_val = _counts(calls)
     assert answer_synth == 2 and answer_val == 2, calls
-    assert "could not produce" in ans.lower()             # abstained
-    assert indepth_synth == 0, calls                      # no In-Depth on an abstained turn
+    assert "could not confirm" in ans.lower()             # graceful abstain (nuanced wording)
+    assert "still wrong" in ans                           # surfaces the specific review finding
+    assert "ans-v" not in ans                             # the flagged draft answer is NOT shipped
+    assert indepth_synth == 1, calls                      # In-Depth KB context IS still generated
+    assert "claim-A-v0" in ans                            # ...and shipped alongside the abstain
 
 
 def test_answer_flagged_without_reason_ships_noise_guard():
@@ -160,3 +164,23 @@ def test_answer_flagged_without_reason_ships_noise_guard():
     assert "ans-v0" in ans                                # shipped the answer
     assert "could not produce" not in ans.lower()         # NOT an abstain
     assert "claim-A-v0" in ans                            # In-Depth still flows through
+
+
+def test_reasoning_trace_is_written_with_steps_and_disposition(tmp_path, monkeypatch):
+    """The hub appends a per-turn reasoning trace: the ordered steps (answer_synth, answer_validator,
+    indepth_synth, indepth_validator) + the disposition + the level_id correlation key."""
+    monkeypatch.setattr(team, "_TRACE_DIR", str(tmp_path))
+    calls = []
+    monkeypatch.setattr(team, "_chat", _factory(calls, [{"answer_ok": True, "drop": []}]))
+    asyncio.run(team.run_team(
+        _MESSAGES, response_format=_RF, orchestrator_model="ORCH", synthesizer_model="SYNTH",
+        validator_model="VALIDATOR", level_id="med-agent-team-low-validated"))
+    lines = (tmp_path / "trace.jsonl").read_text().splitlines()
+    assert len(lines) == 1, lines
+    entry = json.loads(lines[0])
+    assert entry["level_id"] == "med-agent-team-low-validated"
+    assert entry["disposition"] == "full"
+    roles = [s["role"] for s in entry["steps"]]
+    assert "answer_synth" in roles and "answer_validator" in roles
+    assert "indepth_synth" in roles and "indepth_validator" in roles
+    assert entry["ts"] and entry["models"]["synthesizer"] == "SYNTH"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -91,15 +91,17 @@ def test_validator_flag_loops_back_then_passes(monkeypatch):
     assert json.loads(out)["answer"] == "answer-v1"
 
 
-def test_validator_respects_max_loops(monkeypatch):
-    """Persistent flag with max_loops=1 -> exactly one audit + one re-synth, then stop
-    (return the best effort rather than loop forever)."""
+def test_validator_keeps_original_when_revision_still_flagged(monkeypatch):
+    """Re-validate-and-keep-best: the re-synthesis is itself re-audited, and if it is
+    STILL flagged the ORIGINAL draft is kept — a still-flagged rewrite is never trusted
+    over the original (false-flag / drift safety). RED on the old unconditional-accept
+    code, which returned the revision (answer-v1)."""
     calls = []
-    monkeypatch.setattr(team, "_chat", _factory(calls, [False, False, False]))
+    monkeypatch.setattr(team, "_chat", _factory(calls, [False, False]))
     out = asyncio.run(team.run_team(
         _MESSAGES, response_format=_RF,
         orchestrator_model="ORCH", synthesizer_model="SYNTH",
         validator_model="VALIDATOR", validator_max_loops=1))
     val, synth = _counts(calls)
-    assert val == 1 and synth == 2, calls
-    assert json.loads(out)["answer"] == "answer-v1"
+    assert val == 2 and synth == 2, calls            # draft audited + revision re-audited
+    assert json.loads(out)["answer"] == "answer-v0", out   # original kept, revision rejected

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -91,11 +91,10 @@ def test_validator_flag_loops_back_then_passes(monkeypatch):
     assert json.loads(out)["answer"] == "answer-v1"
 
 
-def test_validator_keeps_original_when_revision_still_flagged(monkeypatch):
-    """Re-validate-and-keep-best: the re-synthesis is itself re-audited, and if it is
-    STILL flagged the ORIGINAL draft is kept — a still-flagged rewrite is never trusted
-    over the original (false-flag / drift safety). RED on the old unconditional-accept
-    code, which returned the revision (answer-v1)."""
+def test_validator_abstains_when_revision_still_flagged(monkeypatch):
+    """Re-validate-and-keep-best, ABSTAIN terminal: a still-flagged revision is not
+    shipped, and NEITHER is the flagged original — the turn abstains (never ship an
+    answer the validator flagged). RED on the keep-original code, which returned v0."""
     calls = []
     monkeypatch.setattr(team, "_chat", _factory(calls, [False, False]))
     out = asyncio.run(team.run_team(
@@ -104,4 +103,6 @@ def test_validator_keeps_original_when_revision_still_flagged(monkeypatch):
         validator_model="VALIDATOR", validator_max_loops=1))
     val, synth = _counts(calls)
     assert val == 2 and synth == 2, calls            # draft audited + revision re-audited
-    assert json.loads(out)["answer"] == "answer-v0", out   # original kept, revision rejected
+    ans = json.loads(out)["answer"].lower()
+    assert "answer-v0" not in ans and "answer-v1" not in ans, out  # neither draft shipped
+    assert "could not" in ans or "not produce" in ans, out         # an abstention

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -114,21 +114,22 @@ def test_answer_yellow_fixed_on_retry_shows_message():
     a_synth, _i, a_val, _iv = _counts(calls)
     assert a_synth == 2 and a_val == 2, calls
     assert env["confidence"]["answer"]["level"] == "yellow"
-    assert "ans-v1" in env["answer"]                 # the corrected answer is presented
-    assert "🟡" in env["answer"]                       # yellow caveat in the body fallback
+    assert env["confidence"]["answer"]["note"]             # a clinician-facing note for the tag
+    assert "ans-v1" in env["answer"]                       # the corrected answer is presented
+    assert "confidence" not in env["answer"].lower()       # CLEAN body — confidence is a structured tag, not baked text
 
 
-def test_answer_red_presents_flagged_answer_with_caveat():
-    """Flagged + still flagged after re-synth -> RED: present the (last) answer + the criticism note,
-    NOT hidden, and structured confidence=red carrying the reviewer's reason."""
+def test_answer_red_presents_flagged_answer_with_structured_tag():
+    """Flagged + still flagged after re-synth -> RED: the (last) answer is PRESENTED (not hidden) in
+    a CLEAN body; the criticism rides the structured confidence (the tag's note), not baked text."""
     calls, env = _run([{"answer_ok": False, "answer_issues": "wrong dose"},
                        {"answer_ok": False, "answer_issues": "still wrong"}], validator_max_loops=1)
     a_synth, i_synth, a_val, _iv = _counts(calls)
     assert a_synth == 2 and a_val == 2, calls
     assert env["confidence"]["answer"]["level"] == "red"
-    assert "still wrong" in env["confidence"]["answer"]["note"]   # criticism surfaced
+    assert "still wrong" in env["confidence"]["answer"]["note"]   # criticism in the structured tag note
     assert "ans-v1" in env["answer"]                              # the answer IS presented (not hidden)
-    assert "🔴" in env["answer"]
+    assert "confidence" not in env["answer"].lower()             # clean body — no baked confidence text
     assert i_synth >= 1                                           # In-Depth still generated
 
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,8 +1,8 @@
-"""Validator role: an optional post-synthesis audit that judges the **Answer** and
-**In Depth** sections SEPARATELY and acts granularly — ship a clean draft; if only the
-In Depth is flagged keep the Answer and drop the In Depth; if the Answer is flagged
-re-synthesize, adopt the fix or (if still wrong) abstain. Never ships a wrong direct
-answer. Mocks the LM Studio boundary (`_chat`) and exercises the real run_team.
+"""Validator role: an optional post-synthesis audit that drives TWO INDEPENDENT remediation
+paths — the **Answer** (strict: re-synthesize, else abstain) and the **In Depth** (advisory,
+claim-level: block/strip exactly the claims the validator flags, Answer untouched, never abstain).
+The In Depth is emitted as an enumerated claim list so each claim is individually addressable.
+Mocks the LM Studio boundary (`_chat`) and exercises the real run_team.
 Run: pytest tests/test_validator.py
 """
 
@@ -20,9 +20,9 @@ _RF = {"type": "json_schema", "json_schema": {"name": "chart_answer"}}
 
 
 def _factory(calls, verdicts):
-    """Mock _chat. Orchestrator loop -> no tools (break to synth). Synth -> a versioned
-    two-section envelope. Validator (schema 'validator_verdict') -> a per-section verdict
-    {answer_ok, indepth_ok} pulled from `verdicts`."""
+    """Mock _chat. Orchestrator loop -> no tools (break to synth). Synth -> a versioned envelope
+    whose answer has an **Answer** + a two-bullet **In Depth**. Validator -> a verdict
+    {answer_ok, indepth_drop} pulled from `verdicts` (the real _run_validator clamps the drop)."""
     state = {"synth": 0, "val": 0}
 
     async def fake_chat(client, model, messages, *, tools=None, response_format=None,
@@ -35,12 +35,13 @@ def _factory(calls, verdicts):
             state["val"] += 1
             return {"content": json.dumps({
                 "answer_ok": v["answer_ok"], "answer_issues": "" if v["answer_ok"] else "wrong value",
-                "indepth_ok": v["indepth_ok"], "indepth_issues": "" if v["indepth_ok"] else "fabricated trend"})}
+                "indepth_drop": v.get("indepth_drop", []), "indepth_issues": ""})}
         if response_format is not None:  # synthesis (chart_answer schema)
             n = state["synth"]
             state["synth"] += 1
-            return {"content": json.dumps(
-                {"answer": f"**Answer** ans-v{n} **In Depth** depth-v{n}", "citations": [], "blocks": []})}
+            return {"content": json.dumps({
+                "answer": f"**Answer** ans-v{n}\n\n**In Depth**\n- claim-A-v{n} [1]\n- claim-B-v{n} per WHO",
+                "citations": [], "blocks": []})}
         return {"content": "", "tool_calls": None}  # loop turn
 
     return fake_chat
@@ -54,13 +55,45 @@ def _counts(calls):
 
 def _run(verdicts, **kw):
     calls = []
-    import server.team as t
-    t._chat = _factory(calls, verdicts)
+    monkey = team
+    monkey._chat = _factory(calls, verdicts)
     out = asyncio.run(team.run_team(
         _MESSAGES, response_format=_RF, orchestrator_model="ORCH",
-        synthesizer_model="SYNTH", **kw))
+        synthesizer_model="SYNTH", validator_model="VALIDATOR", **kw))
     return calls, json.loads(out)["answer"]
 
+
+# ---- pure helpers (claim addressability) -----------------------------------
+
+def test_split_answer_indepth_parses_bullets():
+    ans = "**Answer** the answer [3]\n\n**In Depth**\n- first claim [3]\n- second claim per WHO"
+    answer_part, claims = team._split_answer_indepth(ans)
+    assert "the answer" in answer_part and "**In Depth**" not in answer_part
+    assert claims == ["first claim [3]", "second claim per WHO"]
+
+
+def test_split_answer_indepth_no_section():
+    answer_part, claims = team._split_answer_indepth("**Answer** not documented.")
+    assert claims == []
+
+
+def test_strip_indepth_claims_removes_only_flagged():
+    env = json.dumps({"answer": "**Answer** A\n\n**In Depth**\n- keep me\n- drop me\n- keep me too",
+                      "citations": [], "blocks": []})
+    out = json.loads(team._strip_indepth_claims(env, [2]))["answer"]
+    assert "keep me" in out and "keep me too" in out
+    assert "drop me" not in out          # the flagged claim is gone
+    assert "**Answer** A" in out         # the Answer is untouched
+
+
+def test_strip_all_claims_keeps_answer_with_note():
+    env = json.dumps({"answer": "**Answer** A\n\n**In Depth**\n- one\n- two", "citations": [], "blocks": []})
+    out = json.loads(team._strip_indepth_claims(env, [1, 2]))["answer"]
+    assert "**Answer** A" in out and "one" not in out and "two" not in out
+    assert "withheld" in out.lower()
+
+
+# ---- end-to-end through run_team --------------------------------------------
 
 def test_validator_none_skips_audit(monkeypatch):
     monkeypatch.setattr(team, "_chat", _factory([], []))
@@ -69,51 +102,44 @@ def test_validator_none_skips_audit(monkeypatch):
     assert "ans-v0" in json.loads(out)["answer"]
 
 
-def test_validator_both_sections_clean_ships(monkeypatch):
-    calls = []
-    monkeypatch.setattr(team, "_chat", _factory(calls, [{"answer_ok": True, "indepth_ok": True}]))
-    out = asyncio.run(team.run_team(_MESSAGES, response_format=_RF, orchestrator_model="ORCH",
-                                    synthesizer_model="SYNTH", validator_model="VALIDATOR"))
+def test_validator_both_clean_ships_full():
+    calls, ans = _run([{"answer_ok": True, "indepth_drop": []}])
     val, synth = _counts(calls)
     assert val == 1 and synth == 1, calls
-    a = json.loads(out)["answer"]
-    assert "ans-v0" in a and "depth-v0" in a, a  # full two-section answer shipped
+    assert "ans-v0" in ans and "claim-A-v0" in ans and "claim-B-v0" in ans
 
 
-def test_validator_indepth_flagged_keeps_answer_drops_indepth(monkeypatch):
-    """GRANULAR: Answer ok, In Depth flagged -> ship the Answer, drop the In Depth. RED on
-    the old all-or-nothing code (which abstained the whole turn)."""
-    calls = []
-    monkeypatch.setattr(team, "_chat", _factory(calls, [{"answer_ok": True, "indepth_ok": False}]))
-    out = asyncio.run(team.run_team(_MESSAGES, response_format=_RF, orchestrator_model="ORCH",
-                                    synthesizer_model="SYNTH", validator_model="VALIDATOR"))
+def test_validator_indepth_claim_stripped_keeps_answer():
+    """GRANULAR claim-level: drop claim #2 only — keep the Answer + claim #1, no re-synth, no abstain."""
+    calls, ans = _run([{"answer_ok": True, "indepth_drop": [2]}])
     val, synth = _counts(calls)
-    assert val == 1 and synth == 1, calls          # audited once, NOT re-synthesized
-    a = json.loads(out)["answer"]
-    assert "ans-v0" in a, a                         # the grounded Answer is kept
-    assert "depth-v0" not in a, a                   # the flagged In Depth is dropped
-    assert "could not produce" not in a.lower(), a  # NOT a full abstain
+    assert val == 1 and synth == 1, calls       # audited once, NOT re-synthesized
+    assert "ans-v0" in ans                       # Answer kept
+    assert "claim-A-v0" in ans                   # claim #1 kept
+    assert "claim-B-v0" not in ans               # claim #2 stripped
+    assert "could not produce" not in ans.lower()  # NOT a full abstain
 
 
-def test_validator_answer_flagged_resynth_fixes(monkeypatch):
-    """Answer flagged -> re-synthesize -> Answer now ok -> adopt the revision."""
-    calls = []
-    monkeypatch.setattr(team, "_chat", _factory(
-        calls, [{"answer_ok": False, "indepth_ok": False}, {"answer_ok": True, "indepth_ok": True}]))
-    out = asyncio.run(team.run_team(_MESSAGES, response_format=_RF, orchestrator_model="ORCH",
-                                    synthesizer_model="SYNTH", validator_model="VALIDATOR", validator_max_loops=1))
+def test_validator_all_indepth_dropped_keeps_answer():
+    calls, ans = _run([{"answer_ok": True, "indepth_drop": [1, 2]}])
     val, synth = _counts(calls)
-    assert val == 2 and synth == 2, calls
-    assert "ans-v1" in json.loads(out)["answer"]
+    assert val == 1 and synth == 1, calls
+    assert "ans-v0" in ans and "claim-A-v0" not in ans and "claim-B-v0" not in ans
+    assert "could not produce" not in ans.lower()  # In-Depth wipe never abstains the turn
 
 
-def test_validator_answer_flagged_persists_abstains(monkeypatch):
-    """Answer flagged + re-synth still flagged -> abstain (never ship a wrong direct answer)."""
-    calls = []
-    monkeypatch.setattr(team, "_chat", _factory(
-        calls, [{"answer_ok": False, "indepth_ok": False}, {"answer_ok": False, "indepth_ok": False}]))
-    out = asyncio.run(team.run_team(_MESSAGES, response_format=_RF, orchestrator_model="ORCH",
-                                    synthesizer_model="SYNTH", validator_model="VALIDATOR", validator_max_loops=1))
+def test_validator_answer_flagged_resynth_fixes():
+    """ANSWER path is independent: flagged Answer -> re-synthesize -> now ok -> adopt."""
+    calls, ans = _run([{"answer_ok": False, "indepth_drop": []},
+                       {"answer_ok": True, "indepth_drop": []}], validator_max_loops=1)
     val, synth = _counts(calls)
     assert val == 2 and synth == 2, calls
-    assert "could not produce" in json.loads(out)["answer"].lower()
+    assert "ans-v1" in ans
+
+
+def test_validator_answer_flagged_persists_abstains():
+    calls, ans = _run([{"answer_ok": False, "indepth_drop": []},
+                       {"answer_ok": False, "indepth_drop": []}], validator_max_loops=1)
+    val, synth = _counts(calls)
+    assert val == 2 and synth == 2, calls
+    assert "could not produce" in ans.lower()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,105 @@
+"""Validator role: an optional post-synthesis audit round. When a level sets a
+`validator` model, run_team audits the synthesized envelope (the main answer) AND
+the gathered context separately; on a flag it appends specific feedback and
+re-synthesizes, up to `validator_max_loops` cycles. `validator=None` skips it
+entirely (today's behaviour). Mocks the LM Studio boundary (`_chat`) and asserts
+the routing + loop-back, exercising the real run_team. Run: pytest tests/test_validator.py
+"""
+
+import asyncio
+import json
+
+from server import team
+
+_MESSAGES = [
+    {"role": "system", "content": "envelope system"},
+    {"role": "user", "content": "patient chart"},
+    {"role": "user", "content": "the question"},
+]
+_RF = {"type": "json_schema", "json_schema": {"name": "chart_answer"}}
+
+
+def _factory(calls, validator_ok_seq):
+    """Mock _chat. Orchestrator loop -> no tools (break to synth). Synth -> a versioned
+    envelope so re-synth is distinguishable. Validator (model='VALIDATOR') -> a verdict
+    pulled from validator_ok_seq."""
+    state = {"synth": 0, "val": 0}
+
+    async def fake_chat(client, model, messages, *, tools=None, response_format=None,
+                        temperature=None, max_tokens=None, repeat_penalty=None,
+                        dry_multiplier=None, **kwargs):
+        name = (response_format or {}).get("json_schema", {}).get("name")
+        calls.append((model, name))
+        if model == "VALIDATOR":
+            ok = validator_ok_seq[min(state["val"], len(validator_ok_seq) - 1)]
+            state["val"] += 1
+            return {"content": json.dumps(
+                {"ok": ok,
+                 "answer_issues": "" if ok else "trend asserted from a single data point",
+                 "context_issues": ""})}
+        if response_format is not None:  # synthesis (schema-bound)
+            v = state["synth"]
+            state["synth"] += 1
+            return {"content": json.dumps({"answer": f"answer-v{v}", "citations": [], "blocks": []})}
+        return {"content": "", "tool_calls": None}  # loop turn
+
+    return fake_chat
+
+
+def _counts(calls):
+    val = [c for c in calls if c[0] == "VALIDATOR"]
+    synth = [c for c in calls if c[0] == "SYNTH"]
+    return len(val), len(synth)
+
+
+def test_validator_none_skips_audit(monkeypatch):
+    """No validator configured -> no audit call, single synthesis (today's behaviour)."""
+    calls = []
+    monkeypatch.setattr(team, "_chat", _factory(calls, [True]))
+    out = asyncio.run(team.run_team(
+        _MESSAGES, response_format=_RF,
+        orchestrator_model="ORCH", synthesizer_model="SYNTH"))
+    val, synth = _counts(calls)
+    assert val == 0 and synth == 1, calls
+    assert json.loads(out)["answer"] == "answer-v0"
+
+
+def test_validator_clean_answer_no_resynth(monkeypatch):
+    """Validator passes the draft -> audited once, NOT re-synthesized."""
+    calls = []
+    monkeypatch.setattr(team, "_chat", _factory(calls, [True]))
+    out = asyncio.run(team.run_team(
+        _MESSAGES, response_format=_RF,
+        orchestrator_model="ORCH", synthesizer_model="SYNTH",
+        validator_model="VALIDATOR"))
+    val, synth = _counts(calls)
+    assert val == 1 and synth == 1, calls
+    assert json.loads(out)["answer"] == "answer-v0"
+
+
+def test_validator_flag_loops_back_then_passes(monkeypatch):
+    """Flag -> re-synthesize -> re-audit -> pass. Two synth calls, two audits; the
+    returned answer is the corrected re-synthesis (v1)."""
+    calls = []
+    monkeypatch.setattr(team, "_chat", _factory(calls, [False, True]))
+    out = asyncio.run(team.run_team(
+        _MESSAGES, response_format=_RF,
+        orchestrator_model="ORCH", synthesizer_model="SYNTH",
+        validator_model="VALIDATOR", validator_max_loops=2))
+    val, synth = _counts(calls)
+    assert synth == 2 and val == 2, calls
+    assert json.loads(out)["answer"] == "answer-v1"
+
+
+def test_validator_respects_max_loops(monkeypatch):
+    """Persistent flag with max_loops=1 -> exactly one audit + one re-synth, then stop
+    (return the best effort rather than loop forever)."""
+    calls = []
+    monkeypatch.setattr(team, "_chat", _factory(calls, [False, False, False]))
+    out = asyncio.run(team.run_team(
+        _MESSAGES, response_format=_RF,
+        orchestrator_model="ORCH", synthesizer_model="SYNTH",
+        validator_model="VALIDATOR", validator_max_loops=1))
+    val, synth = _counts(calls)
+    assert val == 1 and synth == 2, calls
+    assert json.loads(out)["answer"] == "answer-v1"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,9 +1,9 @@
-"""Validator role: an optional post-synthesis audit round. When a level sets a
-`validator` model, run_team audits the synthesized envelope (the main answer) AND
-the gathered context separately; on a flag it appends specific feedback and
-re-synthesizes, up to `validator_max_loops` cycles. `validator=None` skips it
-entirely (today's behaviour). Mocks the LM Studio boundary (`_chat`) and asserts
-the routing + loop-back, exercising the real run_team. Run: pytest tests/test_validator.py
+"""Validator role: an optional post-synthesis audit that judges the **Answer** and
+**In Depth** sections SEPARATELY and acts granularly — ship a clean draft; if only the
+In Depth is flagged keep the Answer and drop the In Depth; if the Answer is flagged
+re-synthesize, adopt the fix or (if still wrong) abstain. Never ships a wrong direct
+answer. Mocks the LM Studio boundary (`_chat`) and exercises the real run_team.
+Run: pytest tests/test_validator.py
 """
 
 import asyncio
@@ -19,10 +19,10 @@ _MESSAGES = [
 _RF = {"type": "json_schema", "json_schema": {"name": "chart_answer"}}
 
 
-def _factory(calls, validator_ok_seq):
+def _factory(calls, verdicts):
     """Mock _chat. Orchestrator loop -> no tools (break to synth). Synth -> a versioned
-    envelope so re-synth is distinguishable. Validator (model='VALIDATOR') -> a verdict
-    pulled from validator_ok_seq."""
+    two-section envelope. Validator (schema 'validator_verdict') -> a per-section verdict
+    {answer_ok, indepth_ok} pulled from `verdicts`."""
     state = {"synth": 0, "val": 0}
 
     async def fake_chat(client, model, messages, *, tools=None, response_format=None,
@@ -30,79 +30,90 @@ def _factory(calls, validator_ok_seq):
                         dry_multiplier=None, **kwargs):
         name = (response_format or {}).get("json_schema", {}).get("name")
         calls.append((model, name))
-        if model == "VALIDATOR":
-            ok = validator_ok_seq[min(state["val"], len(validator_ok_seq) - 1)]
+        if name == "validator_verdict":
+            v = verdicts[min(state["val"], len(verdicts) - 1)]
             state["val"] += 1
-            return {"content": json.dumps(
-                {"ok": ok,
-                 "answer_issues": "" if ok else "trend asserted from a single data point",
-                 "context_issues": ""})}
-        if response_format is not None:  # synthesis (schema-bound)
-            v = state["synth"]
+            return {"content": json.dumps({
+                "answer_ok": v["answer_ok"], "answer_issues": "" if v["answer_ok"] else "wrong value",
+                "indepth_ok": v["indepth_ok"], "indepth_issues": "" if v["indepth_ok"] else "fabricated trend"})}
+        if response_format is not None:  # synthesis (chart_answer schema)
+            n = state["synth"]
             state["synth"] += 1
-            return {"content": json.dumps({"answer": f"answer-v{v}", "citations": [], "blocks": []})}
+            return {"content": json.dumps(
+                {"answer": f"**Answer** ans-v{n} **In Depth** depth-v{n}", "citations": [], "blocks": []})}
         return {"content": "", "tool_calls": None}  # loop turn
 
     return fake_chat
 
 
 def _counts(calls):
-    val = [c for c in calls if c[0] == "VALIDATOR"]
-    synth = [c for c in calls if c[0] == "SYNTH"]
-    return len(val), len(synth)
+    val = sum(1 for m, n in calls if n == "validator_verdict")
+    synth = sum(1 for m, n in calls if n == "chart_answer")
+    return val, synth
+
+
+def _run(verdicts, **kw):
+    calls = []
+    import server.team as t
+    t._chat = _factory(calls, verdicts)
+    out = asyncio.run(team.run_team(
+        _MESSAGES, response_format=_RF, orchestrator_model="ORCH",
+        synthesizer_model="SYNTH", **kw))
+    return calls, json.loads(out)["answer"]
 
 
 def test_validator_none_skips_audit(monkeypatch):
-    """No validator configured -> no audit call, single synthesis (today's behaviour)."""
-    calls = []
-    monkeypatch.setattr(team, "_chat", _factory(calls, [True]))
-    out = asyncio.run(team.run_team(
-        _MESSAGES, response_format=_RF,
-        orchestrator_model="ORCH", synthesizer_model="SYNTH"))
-    val, synth = _counts(calls)
-    assert val == 0 and synth == 1, calls
-    assert json.loads(out)["answer"] == "answer-v0"
+    monkeypatch.setattr(team, "_chat", _factory([], []))
+    out = asyncio.run(team.run_team(_MESSAGES, response_format=_RF,
+                                    orchestrator_model="ORCH", synthesizer_model="SYNTH"))
+    assert "ans-v0" in json.loads(out)["answer"]
 
 
-def test_validator_clean_answer_no_resynth(monkeypatch):
-    """Validator passes the draft -> audited once, NOT re-synthesized."""
+def test_validator_both_sections_clean_ships(monkeypatch):
     calls = []
-    monkeypatch.setattr(team, "_chat", _factory(calls, [True]))
-    out = asyncio.run(team.run_team(
-        _MESSAGES, response_format=_RF,
-        orchestrator_model="ORCH", synthesizer_model="SYNTH",
-        validator_model="VALIDATOR"))
+    monkeypatch.setattr(team, "_chat", _factory(calls, [{"answer_ok": True, "indepth_ok": True}]))
+    out = asyncio.run(team.run_team(_MESSAGES, response_format=_RF, orchestrator_model="ORCH",
+                                    synthesizer_model="SYNTH", validator_model="VALIDATOR"))
     val, synth = _counts(calls)
     assert val == 1 and synth == 1, calls
-    assert json.loads(out)["answer"] == "answer-v0"
+    a = json.loads(out)["answer"]
+    assert "ans-v0" in a and "depth-v0" in a, a  # full two-section answer shipped
 
 
-def test_validator_flag_loops_back_then_passes(monkeypatch):
-    """Flag -> re-synthesize -> re-audit -> pass. Two synth calls, two audits; the
-    returned answer is the corrected re-synthesis (v1)."""
+def test_validator_indepth_flagged_keeps_answer_drops_indepth(monkeypatch):
+    """GRANULAR: Answer ok, In Depth flagged -> ship the Answer, drop the In Depth. RED on
+    the old all-or-nothing code (which abstained the whole turn)."""
     calls = []
-    monkeypatch.setattr(team, "_chat", _factory(calls, [False, True]))
-    out = asyncio.run(team.run_team(
-        _MESSAGES, response_format=_RF,
-        orchestrator_model="ORCH", synthesizer_model="SYNTH",
-        validator_model="VALIDATOR", validator_max_loops=2))
+    monkeypatch.setattr(team, "_chat", _factory(calls, [{"answer_ok": True, "indepth_ok": False}]))
+    out = asyncio.run(team.run_team(_MESSAGES, response_format=_RF, orchestrator_model="ORCH",
+                                    synthesizer_model="SYNTH", validator_model="VALIDATOR"))
     val, synth = _counts(calls)
-    assert synth == 2 and val == 2, calls
-    assert json.loads(out)["answer"] == "answer-v1"
+    assert val == 1 and synth == 1, calls          # audited once, NOT re-synthesized
+    a = json.loads(out)["answer"]
+    assert "ans-v0" in a, a                         # the grounded Answer is kept
+    assert "depth-v0" not in a, a                   # the flagged In Depth is dropped
+    assert "could not produce" not in a.lower(), a  # NOT a full abstain
 
 
-def test_validator_abstains_when_revision_still_flagged(monkeypatch):
-    """Re-validate-and-keep-best, ABSTAIN terminal: a still-flagged revision is not
-    shipped, and NEITHER is the flagged original — the turn abstains (never ship an
-    answer the validator flagged). RED on the keep-original code, which returned v0."""
+def test_validator_answer_flagged_resynth_fixes(monkeypatch):
+    """Answer flagged -> re-synthesize -> Answer now ok -> adopt the revision."""
     calls = []
-    monkeypatch.setattr(team, "_chat", _factory(calls, [False, False]))
-    out = asyncio.run(team.run_team(
-        _MESSAGES, response_format=_RF,
-        orchestrator_model="ORCH", synthesizer_model="SYNTH",
-        validator_model="VALIDATOR", validator_max_loops=1))
+    monkeypatch.setattr(team, "_chat", _factory(
+        calls, [{"answer_ok": False, "indepth_ok": False}, {"answer_ok": True, "indepth_ok": True}]))
+    out = asyncio.run(team.run_team(_MESSAGES, response_format=_RF, orchestrator_model="ORCH",
+                                    synthesizer_model="SYNTH", validator_model="VALIDATOR", validator_max_loops=1))
     val, synth = _counts(calls)
-    assert val == 2 and synth == 2, calls            # draft audited + revision re-audited
-    ans = json.loads(out)["answer"].lower()
-    assert "answer-v0" not in ans and "answer-v1" not in ans, out  # neither draft shipped
-    assert "could not" in ans or "not produce" in ans, out         # an abstention
+    assert val == 2 and synth == 2, calls
+    assert "ans-v1" in json.loads(out)["answer"]
+
+
+def test_validator_answer_flagged_persists_abstains(monkeypatch):
+    """Answer flagged + re-synth still flagged -> abstain (never ship a wrong direct answer)."""
+    calls = []
+    monkeypatch.setattr(team, "_chat", _factory(
+        calls, [{"answer_ok": False, "indepth_ok": False}, {"answer_ok": False, "indepth_ok": False}]))
+    out = asyncio.run(team.run_team(_MESSAGES, response_format=_RF, orchestrator_model="ORCH",
+                                    synthesizer_model="SYNTH", validator_model="VALIDATOR", validator_max_loops=1))
+    val, synth = _counts(calls)
+    assert val == 2 and synth == 2, calls
+    assert "could not produce" in json.loads(out)["answer"].lower()


### PR DESCRIPTION
Replaces the three-place team-tier config (TEAM_PRESETS code + config.py env + compose) with one declarative file, and makes role-toggling possible.

- `server/levels.yaml` — each key = an advertised `/v1/models` id; fixes per-role models (orchestrator/expert/synthesizer) + optional prompt names. Read per request (bind-mounted, like the prompts) → edit, no rebuild.
- `expert: null` drops the `medical_expert` tool + role for that level (was impossible — the tool was hardcoded).
- `levels_loader.py` mirrors `prompt_loader` (per-request read, fail-loud). `team._tool_definitions(has_expert)` filters; `run_team` gains `has_expert`; the orchestrated tool-loop → synthesis flow is unchanged. `TEAM_PRESETS`/`team_config_for` removed; the per-level env scatter dropped from `config.py`.
- Future flow strategies stay a clean extension (a `strategy:` field + the single `run_team`); none built now.

Tests: 32 hub tests green (`make med-agent-hub-test` + the team/levels suite), incl. a role-toggle test red against the old hardcoded tool list.