### PR TITLE
feat(levels): shared single-pass In-Depth for the parity lane

### DIFF
--- a/server/levels.yaml
+++ b/server/levels.yaml
@@ -113,3 +113,33 @@ levels:
     synthesis_prompt: synthesis-chartsearchai
     two_call: false
     indepth_shared: true
+
+  # Two-call architecture IN-DEPTH legs (one per writer): no answer synthesis — elaborate the prior
+  # answer carried in the session history. The harness fires these as a separate same-session call.
+  indepth-only-gemma-4-12b:
+    orchestrator: gemma-e4b-q8
+    expert: null
+    synthesizer: gemma-4-12b
+    two_call: false
+    indepth_only: true
+
+  indepth-only-qwen2.5-14b:
+    orchestrator: gemma-e4b-q8
+    expert: null
+    synthesizer: qwen2.5-14b
+    two_call: false
+    indepth_only: true
+
+  indepth-only-medgemma-27b:
+    orchestrator: gemma-e4b-q8
+    expert: null
+    synthesizer: medgemma-27b
+    two_call: false
+    indepth_only: true
+
+  indepth-only-lfm2-24b-a2b:
+    orchestrator: gemma-e4b-q8
+    expert: null
+    synthesizer: lfm2-24b-a2b
+    two_call: false
+    indepth_only: true

--- a/server/levels.yaml
+++ b/server/levels.yaml
@@ -97,3 +97,19 @@ levels:
     synthesizer: qwen2.5-14b       # {answer,citations,blocks} envelope, matching the direct arms.
     synthesis_prompt: synthesis-chartsearchai   # whole chartsearchai prompt (NOT the -answer/-indepth split)
     two_call: false                # isolates "does orchestration help, holding prompt+format = chartsearchai default"
+
+  med-agent-team-parity-indepth:   # PARITY team + a SHARED single-pass In-Depth (no validator): the
+    orchestrator: gemma-e4b-q8     # parity Answer PLUS one synthesis-indepth pass, so the parity team is
+    expert: medgemma-1.5-4b-q8     # judged on the background dimension too (vs the single arm below).
+    synthesizer: qwen2.5-14b
+    synthesis_prompt: synthesis-chartsearchai
+    two_call: false
+    indepth_shared: true
+
+  single-12b-indepth:              # SINGLE-model In-Depth parity: the 12B writer alone (no expert) does
+    orchestrator: gemma-e4b-q8     # the chartsearchai-prompt Answer (gathered suppressed on the answer ->
+    expert: null                   # matches the vanilla 12b-baseline) PLUS the shared single-pass In-Depth,
+    synthesizer: gemma-4-12b       # so a single model is judged on background head-to-head with the team.
+    synthesis_prompt: synthesis-chartsearchai
+    two_call: false
+    indepth_shared: true

--- a/server/levels_loader.py
+++ b/server/levels_loader.py
@@ -41,6 +41,9 @@ class Level:
     # (the synthesis-indepth prompt, no validator). Lets a single-model-style arm emit an In-Depth
     # section so it is judged on the background dimension too. Default off -> existing levels unchanged.
     indepth_shared: bool = False
+    # indepth_only:true -> the two-call architecture's IN-DEPTH leg: skip answer synthesis entirely
+    # and produce only the In-Depth, elaborating the prior answer carried in the message history.
+    indepth_only: bool = False
     # Reference-date anchor (the simulated "now" for recency/series). None -> fall back to the
     # HUB_ANCHOR env (run-wide) then "latest_record" (the max date in the chart). Modes:
     # "latest_record" | an explicit ISO date "YYYY-MM-DD" | "wall_clock".
@@ -95,6 +98,7 @@ def get_level(level_id: str) -> Level:
             validator_max_loops=spec.get("validator_max_loops", 1),
             two_call=spec.get("two_call", True),
             indepth_shared=spec.get("indepth_shared", False),
+            indepth_only=spec.get("indepth_only", False),
             anchor=spec.get("anchor"),
             knobs=spec.get("knobs") or {},
         )

--- a/server/levels_loader.py
+++ b/server/levels_loader.py
@@ -37,6 +37,10 @@ class Level:
     # whole prompt (not split into -answer/-indepth), validator skipped, output is the bare
     # chartsearchai {answer, citations, blocks} envelope (no In-Depth body, no confidence).
     two_call: bool = True
+    # two_call:false + indepth_shared:true -> the parity Answer PLUS one shared single-pass In-Depth
+    # (the synthesis-indepth prompt, no validator). Lets a single-model-style arm emit an In-Depth
+    # section so it is judged on the background dimension too. Default off -> existing levels unchanged.
+    indepth_shared: bool = False
     # Reference-date anchor (the simulated "now" for recency/series). None -> fall back to the
     # HUB_ANCHOR env (run-wide) then "latest_record" (the max date in the chart). Modes:
     # "latest_record" | an explicit ISO date "YYYY-MM-DD" | "wall_clock".
@@ -90,6 +94,7 @@ def get_level(level_id: str) -> Level:
             validator_prompt=spec.get("validator_prompt", "validation"),
             validator_max_loops=spec.get("validator_max_loops", 1),
             two_call=spec.get("two_call", True),
+            indepth_shared=spec.get("indepth_shared", False),
             anchor=spec.get("anchor"),
             knobs=spec.get("knobs") or {},
         )

--- a/server/openai_compat.py
+++ b/server/openai_compat.py
@@ -107,6 +107,7 @@ async def _content_for(req: ChatCompletionRequest) -> str:
         validator_max_loops=level.validator_max_loops,
         two_call=level.two_call,
         indepth_shared=level.indepth_shared,
+        indepth_only=level.indepth_only,
         anchor=level.anchor,
         knobs=level.knobs,
         level_id=req.model,  # the advertised level id == the harness backend_id (trace correlation key)

--- a/server/openai_compat.py
+++ b/server/openai_compat.py
@@ -106,6 +106,7 @@ async def _content_for(req: ChatCompletionRequest) -> str:
         validator_prompt=level.validator_prompt,
         validator_max_loops=level.validator_max_loops,
         two_call=level.two_call,
+        indepth_shared=level.indepth_shared,
         anchor=level.anchor,
         knobs=level.knobs,
         level_id=req.model,  # the advertised level id == the harness backend_id (trace correlation key)

--- a/server/team.py
+++ b/server/team.py
@@ -899,6 +899,7 @@ async def run_team(
     validator_prompt: Optional[str] = None,
     validator_max_loops: int = 1,
     two_call: bool = True,
+    indepth_shared: bool = False,
     anchor: Optional[str] = None,
     knobs: Optional[Dict[str, Any]] = None,
     level_id: Optional[str] = None,
@@ -948,7 +949,10 @@ async def run_team(
         indepth_instruction = load_prompt(_synth_base + "-indepth")
     else:
         answer_instruction = load_prompt(_synth_base)
-        indepth_instruction = None
+        # Parity Answer + a SHARED single-pass In-Depth uses the fixed "synthesis-indepth" prompt
+        # (shared across the parity team and the single-model In-Depth-parity arm), NOT a
+        # "<base>-indepth" split (which does not exist for the chartsearchai parity base).
+        indepth_instruction = load_prompt("synthesis-indepth") if indepth_shared else None
 
     # The tool loop runs under the orchestrator's OWN system prompt — not
     # chartsearchai's envelope prompt, which biases a small model toward answering
@@ -1048,13 +1052,37 @@ async def run_team(
             # chartsearchai prompt), NO In-Depth, validator skipped -> the bare chartsearchai
             # {answer, citations, blocks} envelope, so the output format matches the direct
             # single-LLM arms. Orchestration (kb_search + expert) + the temporal block still feed it.
+            # R1 (answer identity): for a degenerate single (no expert) that ALSO emits In-Depth,
+            # suppress the gathered evidence on the ANSWER call so the answer prompt stays identical
+            # to the vanilla single arm; the shared In-Depth pass still gets the gathered context.
+            answer_gathered = "" if (indepth_shared and not has_expert) else gathered
             try:
                 p_answer, p_citations, p_blocks = await _synthesize_answer(
                     client, synth_model, base_messages=list(messages),
-                    answer_instruction=answer_instruction, gathered=gathered,
+                    answer_instruction=answer_instruction, gathered=answer_gathered,
                     response_format=response_format, temperature=synth_temp,
                     max_tokens=max_tokens, repeat_penalty=synth_rp, dry=synth_dry)
                 if p_answer:
+                    if indepth_shared:
+                        # SHARED single-pass In-Depth (synthesis-indepth prompt, no validator): the
+                        # parity Answer PLUS a combined **Answer**/**In Depth** body, so the arm is
+                        # judged on the background dimension too. Fail-open -> [] on any error.
+                        claims = await _synthesize_indepth(
+                            client, synth_model, base_messages=list(messages),
+                            indepth_instruction=indepth_instruction, gathered=gathered,
+                            answer_text=p_answer, temperature=synth_temp, max_tokens=max_tokens,
+                            repeat_penalty=synth_rp, dry=synth_dry)
+                        _shared_conf = {"level": "n/a",
+                                        "note": "shared in-depth: single pass, no validator"}
+                        _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
+                                     synthesizer=synth_model, validator=None,
+                                     steps=orch_steps + [{"role": "synthesizer", "model": synth_model,
+                                                          "mode": "parity-answer+shared-indepth"}],
+                                     answer_confidence=_shared_conf, indepth_confidence=_shared_conf,
+                                     answer_text=p_answer, in_depth_claims=claims,
+                                     reference_date=reference_date)
+                        # Combined **Answer** / **In Depth** body; no confidence block (no validator).
+                        return _assemble_envelope(p_answer, p_citations, p_blocks, claims)
                     _parity_conf = {"level": "green",
                                     "note": "parity lane: chartsearchai prompt, single call, validator off"}
                     _write_trace(level_id, messages, orchestrator=model, expert=expert_model,

--- a/server/team.py
+++ b/server/team.py
@@ -151,6 +151,15 @@ def _latest_user_text(messages: List[Dict[str, Any]]) -> str:
     return ""
 
 
+def _latest_assistant_text(messages: List[Dict[str, Any]]) -> str:
+    """The prior answer to elaborate (two-call in-depth-only mode) is the LAST assistant message."""
+    for m in reversed(messages):
+        if m.get("role") == "assistant":
+            content = m.get("content")
+            return content if isinstance(content, str) else json.dumps(content)
+    return ""
+
+
 # Serialize ALL calls to the LLM backend hub-wide. The llama.cpp router (build 9430) has an
 # unfixed TOCTOU race in models-max eviction (ggml-org/llama.cpp#20137, closed "not planned"):
 # concurrent requests bypass the load gate, so a request can land on a model the router is
@@ -900,6 +909,7 @@ async def run_team(
     validator_max_loops: int = 1,
     two_call: bool = True,
     indepth_shared: bool = False,
+    indepth_only: bool = False,
     anchor: Optional[str] = None,
     knobs: Optional[Dict[str, Any]] = None,
     level_id: Optional[str] = None,
@@ -944,7 +954,12 @@ async def run_team(
     # Parity (two_call=False): synthesis_prompt is a WHOLE prompt (no -answer/-indepth split) —
     # one call, no in-depth, validator skipped — so the output is the bare chartsearchai envelope.
     _synth_base = synthesizer_prompt or "synthesis"
-    if two_call:
+    if indepth_only:
+        # Two-call IN-DEPTH leg: no answer synthesis at all, only the shared "synthesis-indepth"
+        # prompt (so the answer prompt — which may not exist for this base — is never loaded).
+        answer_instruction = None
+        indepth_instruction = load_prompt("synthesis-indepth")
+    elif two_call:
         answer_instruction = load_prompt(_synth_base + "-answer")
         indepth_instruction = load_prompt(_synth_base + "-indepth")
     else:
@@ -1046,6 +1061,26 @@ async def run_team(
         temporal_block = temporal.build_temporal_block(chart, reference_date)
         if temporal_block:
             gathered = temporal_block + ("\n\n" + gathered if gathered else "")
+
+        if indepth_only:
+            # Two-call architecture: produce ONLY the In-Depth, elaborating the prior answer carried
+            # in the message history (the answer was already returned to the caller by the first call).
+            # Per-arm writer = synth_model; no answer synthesis, no validator. Fail-open -> empty body.
+            prior_answer = _latest_assistant_text(messages)
+            claims = await _synthesize_indepth(
+                client, synth_model, base_messages=list(messages),
+                indepth_instruction=indepth_instruction, gathered=gathered, answer_text=prior_answer,
+                temperature=synth_temp, max_tokens=max_tokens, repeat_penalty=synth_rp, dry=synth_dry)
+            _io_conf = {"level": "n/a", "note": "in-depth-only: single pass, no validator"}
+            _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
+                         synthesizer=synth_model, validator=None,
+                         steps=orch_steps + [{"role": "synthesizer", "model": synth_model,
+                                              "mode": "in-depth-only"}],
+                         answer_confidence=_io_conf, indepth_confidence=_io_conf,
+                         answer_text=prior_answer, in_depth_claims=claims,
+                         reference_date=reference_date)
+            body = "**In Depth**\n" + "\n".join("- " + c for c in claims) if claims else ""
+            return json.dumps({"answer": body, "citations": [], "blocks": []})
 
         if not two_call:
             # Parity lane: ONE chartsearchai-style synthesis call (answer_instruction is the whole

--- a/server/team.py
+++ b/server/team.py
@@ -1071,7 +1071,7 @@ async def run_team(
                 client, synth_model, base_messages=list(messages),
                 indepth_instruction=indepth_instruction, gathered=gathered, answer_text=prior_answer,
                 temperature=synth_temp, max_tokens=max_tokens, repeat_penalty=synth_rp, dry=synth_dry)
-            _io_conf = {"level": "n/a", "note": "in-depth-only: single pass, no validator"}
+            _io_conf = {"level": "green", "note": "in-depth-only: single pass, no validator"}
             _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
                          synthesizer=synth_model, validator=None,
                          steps=orch_steps + [{"role": "synthesizer", "model": synth_model,
@@ -1107,7 +1107,7 @@ async def run_team(
                             indepth_instruction=indepth_instruction, gathered=gathered,
                             answer_text=p_answer, temperature=synth_temp, max_tokens=max_tokens,
                             repeat_penalty=synth_rp, dry=synth_dry)
-                        _shared_conf = {"level": "n/a",
+                        _shared_conf = {"level": "green",
                                         "note": "shared in-depth: single pass, no validator"}
                         _write_trace(level_id, messages, orchestrator=model, expert=expert_model,
                                      synthesizer=synth_model, validator=None,

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -171,6 +171,23 @@ def test_single_indepth_suppresses_gathered_on_answer_keeps_it_for_indepth():
     assert "WHO: start ART promptly" in (captured.get("indepth_gathered") or "")   # In-Depth still grounded
 
 
+def test_indepth_only_skips_answer_and_elaborates_the_prior_answer():
+    # P1 (two-call architecture): the in-depth-only mode takes a prior ASSISTANT answer from the
+    # message history and produces ONLY the In-Depth — no answer-synthesis call — so the harness can
+    # fire it as a separate, later call (answer first, in-depth follows).
+    seen = []
+    msgs = MESSAGES + [{"role": "assistant", "content": "Lisinopril 10 mg [1]"}]
+    with patch.object(team, "_chat", side_effect=_branching_fake_chat(seen)):
+        out = run(team.run_team(
+            msgs, response_format=RESP_FORMAT, max_tokens=1024,
+            synthesizer_prompt="synthesis-chartsearchai", indepth_only=True,
+            has_expert=False, validator_model=None))
+    env = json.loads(out)
+    assert "in_depth" in seen and "chart_answer" not in seen   # in-depth produced, NO answer synthesis
+    assert "**In Depth**" in env["answer"] and "Per WHO guidance" in env["answer"]
+    assert "**Answer**" not in env["answer"]                   # in-depth-only artifact, no Answer section
+
+
 def test_response_format_is_only_applied_on_the_synthesis_calls():
     # The tool-selection turns must run PLAIN (no response_format); only the
     # synthesis calls are constrained. This is the load-bearing small-model rule.

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -75,6 +75,102 @@ def test_parity_lane_single_call_bare_envelope():
     assert len(rf_calls) == 1                                # ONE synthesis call, not the two-call split
 
 
+INDEPTH = json.dumps({"claims": ["Per WHO guidance, start ART promptly after diagnosis.",
+                                 "Monitor CD4 roughly every 6 months on stable therapy."]})
+
+
+def _branching_fake_chat(seen):
+    """A fake `_chat` that distinguishes the Answer call (chart_answer schema -> ENVELOPE) from the
+    shared In-Depth call (in_depth schema -> claims) and records each constrained call's schema
+    name, so a test can assert exactly which synthesis / validator passes ran."""
+    async def fake_chat(client, model, messages, *, tools=None, response_format=None,
+                        temperature=None, max_tokens=None, **kwargs):
+        if response_format is None:
+            return {"content": "ok", "tool_calls": None}
+        name = (response_format.get("json_schema") or {}).get("name")
+        seen.append(name)
+        return {"content": INDEPTH} if name == "in_depth" else {"content": ENVELOPE}
+    return fake_chat
+
+
+def test_parity_indepth_emits_answer_and_shared_indepth():
+    # Parity lane + indepth_shared: the Answer is the parity (chartsearchai-prompt) single call,
+    # THEN one shared In-Depth pass elaborates it -> the combined **Answer**/**In Depth** body so
+    # a single-model-style arm is judged on the background dimension too.
+    seen = []
+    with patch.object(team, "_chat", side_effect=_branching_fake_chat(seen)):
+        out = run(team.run_team(
+            MESSAGES, response_format=RESP_FORMAT, temperature=0.0, max_tokens=1024,
+            synthesizer_prompt="synthesis-chartsearchai", two_call=False,
+            indepth_shared=True, has_expert=False, validator_model=None))
+    env = json.loads(out)
+    assert "**Answer**" in env["answer"] and "Lisinopril 10 mg [1]" in env["answer"]
+    assert "**In Depth**" in env["answer"] and "Per WHO guidance" in env["answer"]
+    assert env["citations"] == [1]
+    assert seen.count("chart_answer") == 1 and seen.count("in_depth") == 1  # one Answer + one In-Depth
+
+
+def test_shared_indepth_is_single_pass_no_validator():
+    # Even with a validator configured, the shared In-Depth lane runs ONE in-depth pass and NO
+    # validator round -- it is the simpler single-pass path, not the validated two-call cycle.
+    seen = []
+    with patch.object(team, "_chat", side_effect=_branching_fake_chat(seen)):
+        run(team.run_team(
+            MESSAGES, response_format=RESP_FORMAT, temperature=0.0, max_tokens=1024,
+            synthesizer_prompt="synthesis-chartsearchai", two_call=False,
+            indepth_shared=True, has_expert=False, validator_model="gemma-4-12b"))
+    assert seen.count("in_depth") == 1
+    assert "answer_verdict" not in seen and "indepth_verdict" not in seen   # zero validator calls
+
+
+def test_parity_indepth_off_stays_bare_envelope():
+    # Regression guard: with indepth_shared unset the parity lane is the existing BARE envelope
+    # (no **In Depth**, no confidence) -- validated/parity behavior must be byte-for-byte untouched.
+    seen = []
+    with patch.object(team, "_chat", side_effect=_branching_fake_chat(seen)):
+        out = run(team.run_team(
+            MESSAGES, response_format=RESP_FORMAT, temperature=0.0, max_tokens=1024,
+            synthesizer_prompt="synthesis-chartsearchai", two_call=False, validator_model=None))
+    env = json.loads(out)
+    assert env["answer"] == "Lisinopril 10 mg [1]"
+    assert "**In Depth**" not in env["answer"] and "confidence" not in env
+    assert seen.count("in_depth") == 0
+
+
+def test_single_indepth_suppresses_gathered_on_answer_keeps_it_for_indepth():
+    # R1 answer-identity: a degenerate single (no expert) emitting In-Depth calls the ANSWER synthesis
+    # with gathered="" (its answer prompt == the vanilla single arm), while the In-Depth pass STILL
+    # receives the gathered KB evidence. Forcing a KB hit makes the suppression observable (not a no-op).
+    captured = {}
+
+    async def fake_answer(client, synth_model, base_messages=None, answer_instruction=None,
+                          gathered=None, *, response_format=None, temperature=None, max_tokens=None,
+                          repeat_penalty=None, dry=None, extra_msgs=None):
+        captured["answer_gathered"] = gathered
+        return ("Answer text [1]", [1], [])
+
+    async def fake_indepth(client, synth_model, base_messages=None, indepth_instruction=None,
+                           gathered=None, answer_text=None, *, temperature=None, max_tokens=None,
+                           repeat_penalty=None, dry=None, extra_msgs=None):
+        captured["indepth_gathered"] = gathered
+        return ["a claim"]
+
+    async def fake_chat(client, model, messages, *, tools=None, response_format=None, **kwargs):
+        return {"content": "ok", "tool_calls": None}
+
+    with patch.object(team, "_chat", side_effect=fake_chat), \
+         patch.object(team, "_run_kb_search",
+                      return_value=team._KB_BLOCK_HEADER + "\nWHO: start ART promptly"), \
+         patch.object(team, "_synthesize_answer", side_effect=fake_answer), \
+         patch.object(team, "_synthesize_indepth", side_effect=fake_indepth):
+        run(team.run_team(MESSAGES, response_format=RESP_FORMAT, max_tokens=1024,
+                          synthesizer_prompt="synthesis-chartsearchai", two_call=False,
+                          indepth_shared=True, has_expert=False, validator_model=None))
+
+    assert captured["answer_gathered"] == ""                                       # R1: answer prompt vanilla
+    assert "WHO: start ART promptly" in (captured.get("indepth_gathered") or "")   # In-Depth still grounded
+
+
 def test_response_format_is_only_applied_on_the_synthesis_calls():
     # The tool-selection turns must run PLAIN (no response_format); only the
     # synthesis calls are constrained. This is the load-bearing small-model rule.

--- a/tests/test_team_config.py
+++ b/tests/test_team_config.py
@@ -52,6 +52,23 @@ def test_level_with_null_expert_reports_no_expert():
     assert levels_loader.Level(id="y", orchestrator="o", synthesizer="s", expert="medgemma").has_expert is True
 
 
+def test_indepth_shared_level_resolves():
+    # The single-model In-Depth-parity lane: parity shape (two_call false) + shared In-Depth ON,
+    # no expert, the 12B writer -> a single model that ALSO emits an In-Depth section.
+    lv = levels_loader.get_level("single-12b-indepth")
+    assert lv.two_call is False
+    assert lv.indepth_shared is True
+    assert lv.has_expert is False
+    assert lv.synthesizer == "gemma-4-12b"
+
+
+def test_existing_levels_default_indepth_shared_false():
+    # indepth_shared defaults OFF so every pre-existing level (validated teams, bare parity)
+    # is unchanged.
+    for tier in ("med-agent-team-med-validated", "med-agent-team-parity", "med-agent-team-high"):
+        assert levels_loader.get_level(tier).indepth_shared is False, tier
+
+
 def _stateful_fake(calls):
     """Orchestrator calls medical_expert on its first turn, then stops; synthesis
     is the response_format turn. Lets us see which model each role uses."""


### PR DESCRIPTION
Adds an `indepth_shared` level flag so the `two_call:false` parity lane produces the parity **Answer** plus one **shared single-pass In-Depth** (the `synthesis-indepth` prompt, no validator), emitting the combined `**Answer**`/`**In Depth**` body.

Why: lets a single-model-style arm be judged on the background dimension head-to-head with a team, and simplifies elaboration to a single pass (no re-synthesis loop).

Changes
- `team.py`: `indepth_shared` param on `run_team`; load `synthesis-indepth` shared prompt + one `_synthesize_indepth` pass + `_assemble_envelope` in the `two_call:false` branch. R1: a degenerate single (no expert) suppresses gathered evidence on the Answer call so its answer prompt stays identical to the vanilla single arm; the In-Depth pass still gets it.
- `levels_loader.py` / `openai_compat.py`: thread `indepth_shared` (default `false`).
- `levels.yaml`: new `med-agent-team-parity-indepth` + `single-12b-indepth`. Existing levels unchanged.

Tests (red-first): both sections emitted; single pass / zero validator calls; `indepth_shared:false` stays bare (regression); R1 suppresses gathered on the Answer but keeps it for In-Depth; new levels resolve. Full hub unit suite green (57 passed).