### PR TITLE
feat(levels): generic indepth-only:<writer> + advertise dynamic legs

### DIFF
--- a/server/levels_loader.py
+++ b/server/levels_loader.py
@@ -82,6 +82,19 @@ def get_level(level_id: str) -> Level:
     """Resolve one level. Fail loud on an unknown id or a missing required field."""
     raw = _load_raw()
     if level_id not in raw:
+        # Generic In-Depth leg: "indepth-only:<writer-model>" resolves dynamically to a single
+        # shared-prompt In-Depth pass on ANY router model — no hand-authored level needed — so the
+        # two-call In-Depth is available for parity across every arm/run. The orchestrator only
+        # carries the prior answer in session history; the writer (synthesizer) does the In-Depth.
+        if level_id.startswith("indepth-only:") and level_id.split(":", 1)[1]:
+            return Level(
+                id=level_id,
+                orchestrator="gemma-e4b-q8",
+                synthesizer=level_id.split(":", 1)[1],
+                expert=None,
+                two_call=False,
+                indepth_only=True,
+            )
         raise KeyError(f"unknown level {level_id!r}; levels.yaml defines {list(raw)}")
     spec = raw[level_id] or {}
     try:

--- a/server/openai_compat.py
+++ b/server/openai_compat.py
@@ -47,8 +47,22 @@ def _advertised_models() -> List[str]:
     chartsearchai's exact-match served-model validation both accept them. Each id
     selects which model runs each role (orchestrator/synthesizer/expert) per request
     — one instance serves any config, no reboot. Raw backends stay callable via
-    passthrough but aren't listed."""
-    return level_ids()
+    passthrough but aren't listed.
+
+    Also advertise the generic two-call In-Depth leg ``indepth-only:<writer>`` for every
+    model the router serves, so chartsearchai's exact-match validation accepts the dynamic
+    levels get_level() resolves on the fly (no hand-authored per-writer level needed)."""
+    ids = list(level_ids())
+    try:
+        import httpx
+        resp = httpx.get(f"{llm_config.base_url.rstrip('/')}/v1/models", timeout=3.0)
+        for m in resp.json().get("data", []):
+            mid = m.get("id")
+            if mid:
+                ids.append(f"indepth-only:{mid}")
+    except Exception:
+        pass  # router unreachable -> advertise levels only; direct-to-hub callers still work
+    return ids
 
 
 @router.get("/v1/models")

--- a/tests/test_team_config.py
+++ b/tests/test_team_config.py
@@ -69,6 +69,25 @@ def test_existing_levels_default_indepth_shared_false():
         assert levels_loader.get_level(tier).indepth_shared is False, tier
 
 
+def test_generic_indepth_only_resolves_any_writer():
+    # "indepth-only:<writer>" resolves dynamically to a single-pass In-Depth leg for ANY router
+    # model, with no hand-authored level — so the two-call In-Depth is available for parity across
+    # every arm/run (the writer does the shared-prompt In-Depth; orchestrator just carries history).
+    for writer in ("mistral-nemo-12b-q8", "granite-3.3-8b", "qwen3.6-35b"):
+        lv = levels_loader.get_level(f"indepth-only:{writer}")
+        assert lv.synthesizer == writer
+        assert lv.indepth_only is True
+        assert lv.two_call is False
+        assert lv.has_expert is False
+
+
+def test_unknown_non_indepth_level_still_fails_loud():
+    # The dynamic path is gated to the "indepth-only:" prefix — anything else still raises.
+    import pytest
+    with pytest.raises(KeyError):
+        levels_loader.get_level("totally-bogus-level")
+
+
 def _stateful_fake(calls):
     """Orchestrator calls medical_expert on its first turn, then stops; synthesis
     is the response_format turn. Lets us see which model each role uses."""

--- a/tests/test_team_config.py
+++ b/tests/test_team_config.py
@@ -88,6 +88,24 @@ def test_unknown_non_indepth_level_still_fails_loud():
         levels_loader.get_level("totally-bogus-level")
 
 
+def test_advertised_models_includes_dynamic_indepth_legs(monkeypatch):
+    # chartsearchai exact-match-validates the requested model against /v1/models, so the dynamic
+    # indepth-only:<writer> legs MUST be advertised for every router model — else they 400 mid-run
+    # (the regression this guards). Mock the router's /v1/models so the test is hermetic.
+    import httpx
+    from server import openai_compat
+
+    class _Resp:
+        def json(self):
+            return {"data": [{"id": "mistral-nemo-12b-q8"}, {"id": "qwen3.6-35b"}]}
+
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: _Resp())
+    ids = openai_compat._advertised_models()
+    assert "indepth-only:mistral-nemo-12b-q8" in ids
+    assert "indepth-only:qwen3.6-35b" in ids
+    assert "med-agent-team-med" in ids  # static levels still advertised alongside
+
+
 def _stateful_fake(calls):
     """Orchestrator calls medical_expert on its first turn, then stops; synthesis
     is the response_format turn. Lets us see which model each role uses."""


### PR DESCRIPTION
Generic two-call In-Depth so any router model gets a parity In-Depth pass with no hand-authored level.

- `get_level("indepth-only:<writer>")` resolves dynamically — orchestrator carries history, the writer does a single shared-prompt In-Depth pass.
- `_advertised_models()` advertises `indepth-only:<m>` for every router model, so chartsearchai's exact-match /v1/models validation accepts the dynamic legs (they 400'd mid-run otherwise).
- Tests: generic resolution (red-first), non-indepth ids still fail loud, advertised-legs regression.

Verified end-to-end: a new arm's In-Depth returns 200 through the full chartsearchai path.