### PR TITLE
ci: publish the hub image to GHCR, and verify it actually starts

### DIFF
--- a/.github/workflows/hub-ci.yml
+++ b/.github/workflows/hub-ci.yml
@@ -37,5 +37,61 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # HUB_BUILD_REVISION must be the real commit: validate_config() rejects
+      # the Dockerfile's "unknown" default, so an image built without it builds
+      # fine and then refuses to start.
       - name: Build image
-        run: docker build .
+        run: |
+          docker build --build-arg HUB_BUILD_REVISION="${GITHUB_SHA}" -t hub-ci-candidate .
+
+      # Building is not evidence the image runs: validate_config() executes at
+      # import, so a container that starts and answers /health is what proves
+      # the packaged configuration is actually serviceable.
+      - name: Verify the image starts and serves /health
+        run: |
+          docker run -d --name hub-smoke -p 8080:8080 hub-ci-candidate
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:8080/health >/dev/null 2>&1; then
+              echo "healthy after ${i}s"
+              docker rm -f hub-smoke >/dev/null
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "image never served /health:" >&2
+          docker logs hub-smoke >&2
+          docker rm -f hub-smoke >/dev/null
+          exit 1
+
+  # Publish so consumers can pin an image instead of vendoring this repo and
+  # building from source. Catalyst's demo stack in particular has no other
+  # reason to require a checkout of the hub.
+  publish:
+    # Only from main: a published tag should always name reviewed, merged code,
+    # and pull requests (especially from forks) cannot push packages anyway.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [unit-and-contract, docker-build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Both tags point at the same image. The commit-SHA tag is the one to
+      # deploy: it is immutable and reproducible, which `latest` is not.
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: |
+            HUB_BUILD_REVISION=${{ github.sha }}
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
## Summary

- Publish `ghcr.io/pmanko/med-agent-hub` on every push to `main`, tagged with both the commit SHA and `latest`.
- Pass `HUB_BUILD_REVISION` at build time, which the image requires in order to start.
- Make `docker-build` run the image and check `/health`, not just build it.

## Why

The hub ships only as a container but publishes nothing, so every consumer has to vendor this repo and build from source. Catalyst's demo stack needs the hub for exactly one thing — a running service — and had no other reason to require a checkout of it.

## The bug this also fixes

`validate_config()` requires a 40-character commit SHA and rejects the Dockerfile's `HUB_BUILD_REVISION=unknown` default. So `docker build .` — what CI has been running — produces an image that builds cleanly and then **exits 1 on startup**:

```
ValueError: HUB_BUILD_REVISION must be the 40-character Git commit for packaged deployments.
```

CI never caught it because it only ever built the image, never ran it.

## Validation

Both directions verified locally against this branch's tip:

| Build | Result |
| --- | --- |
| `docker build .` | container exits 1 on the `HUB_BUILD_REVISION` error |
| `docker build --build-arg HUB_BUILD_REVISION=<sha> .` | `/health` answers in 2s; image carries `org.opencontainers.image.revision=<sha>` |

## Notes for reviewers

- The SHA tag is the one deployments should pin — it is immutable and reproducible; `latest` is neither.
- `publish` is gated on `github.ref == 'refs/heads/main'` and needs both existing jobs, so a published tag always names reviewed, merged code. Fork PRs cannot push packages regardless.
- First run on `main` will create the package; it may need to be flipped to public in repo settings before anonymous pulls work.