### PR TITLE
Fix paged context slices and citation grounding

### DIFF
--- a/server/context_sources.py
+++ b/server/context_sources.py
@@ -27,7 +27,7 @@ from . import kb
 from .chart_serializer import render_chart
 from .config import llm_config, querystore_config
 from .patient_ledger_cache import PatientLedgerCache, default_patient_ledger_cache
-from .querystore_client import QueryStoreClient
+from .querystore_client import ContextSliceFetch, QueryStoreClient
 from .ranked_candidates import resolve_ranked_hits_with_retry
 
 _CHART_MARKER = "Patient records (most recent first):"
@@ -225,6 +225,9 @@ class EvidenceLedger:
     records: Tuple[EvidenceRecord, ...]
     original_text: str = field(default="", compare=False)
     preamble: str = field(default="", compare=False)
+    source_metadata: Mapping[str, Mapping[str, Any]] = field(
+        default_factory=dict, compare=False
+    )
 
     @property
     def source_names(self) -> Tuple[str, ...]:
@@ -507,7 +510,7 @@ class QueryStoreSource:
                 source=self.name,
             ) from exc
         rank_by_identity = await self._ranked_candidate_identities(request, raw_records)
-        slice_tiers = await self._slice_tiers(request)
+        slice_tiers, slice_metadata = await self._slice_selection(request)
         chart, mappings = render_chart(raw_records)
         records: list[EvidenceRecord] = []
         raw_by_key = {
@@ -544,32 +547,50 @@ class QueryStoreSource:
                     raw=raw,
                 )
             )
-        return EvidenceLedger(tuple(records), original_text=chart)
+        source_metadata = (
+            {self.name: {"context_slice": slice_metadata}} if slice_metadata else {}
+        )
+        return EvidenceLedger(
+            tuple(records), original_text=chart, source_metadata=source_metadata
+        )
 
-    async def _slice_tiers(
+    async def _slice_selection(
         self, request: ContextRequest
-    ) -> dict[tuple[Optional[str], Optional[str]], str]:
+    ) -> tuple[
+        dict[tuple[Optional[str], Optional[str]], str], dict[str, Any]
+    ]:
         """Selection tier per record identity from querystore's shared context slice, or
         ``{}`` when the client predates the contract or the slice call fails — the local
         policy remains the degradation path, never a blocked turn."""
         fetch = getattr(self.client, "fetch_context_slice", None)
         if fetch is None:
-            return {}
+            return {}, {}
         try:
             # interpret=True: cue routing, temporal gating, and retrieval preprocessing run
             # server-side (querystore ADR Decision 18) — the RAW question goes over, so the
             # hub's and bundled's interpretations cannot drift.
-            rows = await fetch(request.patient, request.question.strip(), interpret=True)
+            result = await fetch(
+                request.patient, request.question.strip(), interpret=True
+            )
         except Exception:
-            return {}
+            return {}, {}
+        if not isinstance(result, ContextSliceFetch):
+            return {}, {}
         tiers: dict[tuple[Optional[str], Optional[str]], str] = {}
-        for row in rows or []:
+        for row in result.records:
             if not isinstance(row, Mapping):
                 continue
             tier = row.get("tier")
             if isinstance(tier, str) and tier:
                 tiers[(row.get("resourceType"), row.get("resourceUuid"))] = tier
-        return tiers
+        return tiers, {
+            "slice_id": result.slice_id,
+            "total_count": result.total_count,
+            "chart_size": result.chart_size,
+            "chart_truncated": result.chart_truncated,
+            "effective_types": list(result.effective_types),
+            "temporal_applied": result.temporal_applied,
+        }
 
     async def _ranked_candidate_identities(
         self, request: ContextRequest, raw_records: list[dict[str, Any]]
@@ -639,7 +660,17 @@ class SourceRegistry:
             )
         original_text = ledgers[0].original_text if len(ledgers) == 1 else ""
         preamble = "".join(ledger.preamble for ledger in ledgers if ledger.preamble)
-        return EvidenceLedger(records, original_text=original_text, preamble=preamble)
+        source_metadata = {
+            source_name: metadata
+            for ledger in ledgers
+            for source_name, metadata in ledger.source_metadata.items()
+        }
+        return EvidenceLedger(
+            records,
+            original_text=original_text,
+            preamble=preamble,
+            source_metadata=source_metadata,
+        )
 
     def _resolve(self, request: ContextRequest) -> Tuple[ContextSource, ...]:
         requested = request.sources or ((request.source,) if request.source else ())

--- a/server/engine.py
+++ b/server/engine.py
@@ -236,6 +236,10 @@ def _context_summary(state: _State) -> Dict[str, Any]:
     return {
         "schema_version": "context_view.v1",
         "sources": list(state.ledger.source_names),
+        "source_metadata": {
+            name: dict(metadata)
+            for name, metadata in state.ledger.source_metadata.items()
+        },
         "ledger_records": len(state.ledger.records),
         "selection_mode": view.mode if view else "none",
         "included_ids": list(view.included_ids) if view else [],
@@ -365,7 +369,12 @@ def _ledger_after_drug_injection(
                 mandatory=resource_type.lower() == "drugreference",
             )
         )
-    return EvidenceLedger(tuple(records), original_text=chart, preamble=ledger.preamble)
+    return EvidenceLedger(
+        tuple(records),
+        original_text=chart,
+        preamble=ledger.preamble,
+        source_metadata=ledger.source_metadata,
+    )
 
 
 def _fixed_context_text(

--- a/server/querystore_client.py
+++ b/server/querystore_client.py
@@ -152,7 +152,9 @@ class QueryStoreClient:
                         "Querystore changed the patient chart snapshot while paging"
                     )
                 start += len(page)
-                if not page or len(page) < page_size or start >= expected_total:
+                # OpenMRS may cap `limit` below the requested page size. `totalCount`, not the
+                # requested limit, determines whether more records remain.
+                if not page or start >= expected_total:
                     break
         if expected_total is None or len(records) != expected_total:
             raise ValueError(

--- a/server/querystore_client.py
+++ b/server/querystore_client.py
@@ -40,6 +40,19 @@ class PatientLedgerFetch:
     etag: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class ContextSliceFetch:
+    """Complete tiered selection plus the server's auditable selection metadata."""
+
+    records: list[dict[str, Any]]
+    slice_id: str
+    total_count: int
+    chart_size: int
+    chart_truncated: bool
+    effective_types: tuple[str, ...]
+    temporal_applied: bool
+
+
 class QueryStoreClient:
     """Reads a patient's chart from querystore over REST. Auth is OpenMRS Basic (a service account)."""
 
@@ -174,37 +187,128 @@ class QueryStoreClient:
         temporal: bool = False,
         interpret: bool = False,
         limit: int = 500,
-    ) -> list[dict[str, Any]]:
+    ) -> ContextSliceFetch:
         """The tier-tagged context slice (querystore ADR Decision 17) for one question.
 
         The caller's question interpretation rides as ``types`` (typed-complete resource
         types) and ``temporal`` (recency anchor applies). Each returned record carries a
         ``tier`` — ``mandatory`` records are never droppable downstream. Like ranked search
-        this window is question-dependent and uncached: no ``snapshotId``/``ETag``.
+        this window is question-dependent and uncached: no full-chart ``snapshotId``/``ETag``.
+        Every page does carry one ``sliceId`` for the complete ordered selection; mixed pages
+        are rejected instead of silently joining two question-context versions.
         """
-        params: dict[str, Any] = {
+        base_params: dict[str, Any] = {
             "patient": patient_uuid,
             "mode": "context",
             "temporal": "true" if temporal else "false",
             "limit": limit,
         }
         if interpret:
-            params["interpret"] = "true"
+            base_params["interpret"] = "true"
         if question:
-            params["q"] = question
+            base_params["q"] = question
         if types:
-            params["types"] = ",".join(sorted(types))
+            base_params["types"] = ",".join(sorted(types))
+
+        records: list[dict[str, Any]] = []
+        seen_ids: set[tuple[str, str]] = set()
+        start = 0
+        expected: Optional[tuple[str, int, int, bool, tuple[str, ...], bool]] = None
         async with httpx.AsyncClient(timeout=self._timeout, auth=self._auth) as client:
-            resp = await client.get(self._url, params=params)
-            resp.raise_for_status()
-            body = resp.json()
-        rows = body.get("results")
-        if not isinstance(rows, list):
-            raise ValueError("Querystore did not return a valid context slice page")
-        for row in rows:
-            if not isinstance(row, dict) or not isinstance(row.get("tier"), str):
-                raise ValueError("Querystore returned a context-slice record without a tier")
-        return rows
+            while True:
+                params = {**base_params, "startIndex": start}
+                resp = await client.get(self._url, params=params)
+                resp.raise_for_status()
+                body = resp.json()
+                rows = body.get("results")
+                if not isinstance(rows, list):
+                    raise ValueError("Querystore did not return a valid context slice page")
+
+                total = body.get("totalCount")
+                chart_size = body.get("chartSize")
+                chart_truncated = body.get("chartTruncated")
+                slice_id = body.get("sliceId")
+                effective_types = body.get("effectiveTypes")
+                temporal_applied = body.get("temporalApplied")
+                if (
+                    type(total) is not int
+                    or total < 0
+                    or type(chart_size) is not int
+                    or chart_size < 0
+                    or not isinstance(chart_truncated, bool)
+                    or not isinstance(slice_id, str)
+                    or not slice_id.strip()
+                    or not isinstance(effective_types, list)
+                    or any(
+                        not isinstance(item, str) or not item.strip()
+                        for item in effective_types
+                    )
+                    or not isinstance(temporal_applied, bool)
+                ):
+                    raise ValueError(
+                        "Querystore did not return valid context-slice metadata"
+                    )
+                page_identity = (
+                    slice_id,
+                    total,
+                    chart_size,
+                    chart_truncated,
+                    tuple(effective_types),
+                    temporal_applied,
+                )
+                if expected is None:
+                    expected = page_identity
+                elif page_identity != expected:
+                    raise InconsistentSnapshotError(
+                        "Querystore changed the context slice while paging"
+                    )
+
+                for row in rows:
+                    if (
+                        not isinstance(row, dict)
+                        or not isinstance(row.get("tier"), str)
+                        or not row["tier"].strip()
+                    ):
+                        raise ValueError(
+                            "Querystore returned a context-slice record without a tier"
+                        )
+                    resource_type = row.get("resourceType")
+                    resource_uuid = row.get("resourceUuid")
+                    if (
+                        not isinstance(resource_type, str)
+                        or not resource_type.strip()
+                        or not isinstance(resource_uuid, str)
+                        or not resource_uuid.strip()
+                    ):
+                        raise ValueError(
+                            "Querystore returned a context-slice record without a stable identity"
+                        )
+                    identity = (resource_type, resource_uuid)
+                    if identity in seen_ids:
+                        raise ValueError(
+                            "Querystore returned a duplicate context-slice record while paging"
+                        )
+                    seen_ids.add(identity)
+                records.extend(rows)
+                start += len(rows)
+                if not rows or start >= total:
+                    break
+
+        if expected is None or len(records) != expected[1]:
+            expected_total = expected[1] if expected else None
+            raise ValueError(
+                "Querystore returned a truncated context slice: "
+                f"expected {expected_total} records, received {len(records)}"
+            )
+        return ContextSliceFetch(
+            records=records,
+            slice_id=expected[0],
+            total_count=expected[1],
+            chart_size=expected[2],
+            chart_truncated=expected[3],
+            effective_types=expected[4],
+            temporal_applied=expected[5],
+        )
 
     async def search_patient_records(
         self, patient_uuid: str, query: str, *, limit: int = 20

--- a/server/team.py
+++ b/server/team.py
@@ -453,6 +453,40 @@ def _claim_fragments_for_index(answer: str, index: int) -> List[str]:
     return fragments
 
 
+def _citation_clusters(text: str) -> List[Dict[str, Any]]:
+    """Partition ``text`` into citation clusters for per-item grounding.
+
+    Adjacent markers with no word-bearing text between them (a collective claim like a
+    ``74 kg ... to 71 kg [1][2]`` change, whose sources are checked TOGETHER) stay in ONE
+    cluster; markers each preceded by their own item text (an enumeration like
+    ``cotrimoxazole [2], lamivudine [3]``) each form their OWN cluster so each is grounded
+    against only its own source — the fix for compound-citation verdict coupling. Each cluster's
+    claim is its text span with citation markers stripped; a cluster owns the span from the end of
+    the previous cluster's last marker to the start of the next cluster (the final cluster runs to
+    end-of-text, so trailing punctuation is preserved). Returns ``[{"indices": [int, ...],
+    "claim": str}, ...]`` in order; empty when ``text`` cites nothing."""
+    markers = list(_INLINE_CITATION_RE.finditer(text or ""))
+    if not markers:
+        return []
+    spans: List[Dict[str, Any]] = []
+    prev_end = 0
+    for marker in markers:
+        idx = int(marker.group(1))
+        between = text[prev_end : marker.start()]
+        if not spans or re.search(r"\w", between):
+            spans.append({"indices": [idx], "text_start": prev_end, "last_end": marker.end()})
+        else:
+            spans[-1]["indices"].append(idx)
+            spans[-1]["last_end"] = marker.end()
+        prev_end = marker.end()
+    clusters: List[Dict[str, Any]] = []
+    for position, span in enumerate(spans):
+        span_end = spans[position + 1]["text_start"] if position + 1 < len(spans) else len(text)
+        claim = _INLINE_CITATION_RE.sub("", text[span["text_start"] : span_end]).strip()
+        clusters.append({"indices": span["indices"], "claim": claim})
+    return clusters
+
+
 _ENTAILMENT_SYSTEM_PROMPT = (
     "You are a strict clinical fact-checker. For each PAIR, decide whether the SOURCE record "
     "supports the STATEMENT. Answer NO if: the statement is about a different person or describes "
@@ -607,7 +641,20 @@ async def _ground_references(
                 for fragment in _claim_fragments_for_index(answer or "", idx)
             ]
         for usage in usages:
-            claim = _INLINE_CITATION_RE.sub("", str(usage.get("text") or "")).strip()
+            usage_text = str(usage.get("text") or "")
+            # Enumeration split: when this citation sits in exactly ONE of several clusters (its own
+            # item, e.g. one drug in a comma-separated list), scope its claim to that item so it is
+            # grounded against only its own source instead of a combined multi-item verdict. Collective
+            # claims (adjacent markers -> a single cluster) and citations reused across clusters fall
+            # back to the whole-usage claim, preserving combined-source and deterministic-temporal
+            # behavior. Single-index parsing is deliberate (see _INLINE_CITATION_RE): a value bracket
+            # like [120, 80] is never a marker, so it is never split into phantom references.
+            clusters = _citation_clusters(usage_text)
+            idx_clusters = [cluster for cluster in clusters if idx in cluster["indices"]]
+            if len(clusters) > 1 and len(idx_clusters) == 1:
+                claim = idx_clusters[0]["claim"]
+            else:
+                claim = _INLINE_CITATION_RE.sub("", usage_text).strip()
             if not claim or not source:
                 continue
             key = (

--- a/tests/test_context_sources.py
+++ b/tests/test_context_sources.py
@@ -25,6 +25,7 @@ from server.context_sources import (
 )
 from server.patient_ledger_cache import PatientLedgerCache
 from server.querystore_client import PatientLedgerFetch
+from server.querystore_client import ContextSliceFetch
 
 
 class WordTokenCounter:
@@ -614,7 +615,15 @@ class _FakeQueryStoreClient:
         self.slice_calls.append((question, interpret))
         if self.slice_error is not None:
             raise self.slice_error
-        return list(self.slice_records)
+        return ContextSliceFetch(
+            records=list(self.slice_records),
+            slice_id="slice-1",
+            total_count=len(self.slice_records),
+            chart_size=len(self._records),
+            chart_truncated=False,
+            effective_types=("drug_order",),
+            temporal_applied=True,
+        )
 
 
 def test_querystore_mapping_keeps_the_matching_raw_record_when_invalid_rows_are_skipped():
@@ -1620,6 +1629,14 @@ def test_querystore_slice_tiers_annotate_records_and_mandatory_tier_wins():
     assert by_uuid["cond-1"].mandatory is True
     assert by_uuid["med-1"].slice_tier == "typed"
     assert by_uuid["noise-1"].slice_tier is None
+    assert ledger.source_metadata["querystore"]["context_slice"] == {
+        "slice_id": "slice-1",
+        "total_count": 2,
+        "chart_size": 3,
+        "chart_truncated": False,
+        "effective_types": ["drug_order"],
+        "temporal_applied": True,
+    }
     # The RAW question goes over with interpret=True — interpretation is querystore's.
     assert client.slice_calls, "the source must request the shared slice"
     question, interpret = client.slice_calls[0]
@@ -1665,4 +1682,3 @@ def test_slice_selected_records_are_never_zero_relevance():
     reasons = {record.stable_id: reason for record, reason in ranked}
     assert reasons["qs:drug_order:med-1"] == "slice_typed"
     assert reasons["qs:obs:noise-1"] == "zero_relevance"
-

--- a/tests/test_querystore_client.py
+++ b/tests/test_querystore_client.py
@@ -144,6 +144,47 @@ def test_full_chart_accepts_multiple_pages(monkeypatch):
     assert result.snapshot_id == "snap-1"
 
 
+def test_full_chart_continues_when_server_caps_each_page_below_the_requested_limit(
+    monkeypatch,
+):
+    fake = _FakeResponses(
+        [
+            _page(
+                [
+                    {"resourceType": "obs", "resourceUuid": "one"},
+                    {"resourceType": "obs", "resourceUuid": "two"},
+                ],
+                total=5,
+            ),
+            _page(
+                [
+                    {"resourceType": "obs", "resourceUuid": "three"},
+                    {"resourceType": "obs", "resourceUuid": "four"},
+                ],
+                total=5,
+            ),
+            _page([{"resourceType": "obs", "resourceUuid": "five"}], total=5),
+        ]
+    )
+    monkeypatch.setattr("server.querystore_client.httpx.AsyncClient", fake)
+
+    result = _run(
+        QueryStoreClient("http://openmrs", "service", "secret").fetch_patient_ledger(
+            "patient-1", page_size=500
+        )
+    )
+
+    assert [record["resourceUuid"] for record in result.records] == [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+    ]
+    assert [request["params"]["startIndex"] for request in fake.requests] == [0, 2, 4]
+    assert all(request["params"]["limit"] == 500 for request in fake.requests)
+
+
 def test_full_chart_rejects_duplicate_record_across_pages(monkeypatch):
     fake = _FakeResponses(
         [

--- a/tests/test_querystore_client.py
+++ b/tests/test_querystore_client.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from server.querystore_client import (
+    ContextSliceFetch,
     InconsistentSnapshotError,
     PatientLedgerFetch,
     QueryStoreClient,
@@ -40,6 +41,32 @@ def _page(records, total, snapshot_id="snap-1", etag='"etag-1"', status=200):
         body["snapshotId"] = snapshot_id
     headers = {"ETag": etag} if etag is not None else {}
     return httpx.Response(status, json=body, headers=headers, request=request)
+
+
+def _context_page(
+    records,
+    total,
+    *,
+    slice_id="slice-1",
+    chart_size=365,
+    chart_truncated=False,
+    effective_types=None,
+    temporal_applied=True,
+):
+    request = httpx.Request("GET", "http://openmrs/querystore")
+    return httpx.Response(
+        200,
+        json={
+            "results": records,
+            "totalCount": total,
+            "sliceId": slice_id,
+            "chartSize": chart_size,
+            "chartTruncated": chart_truncated,
+            "effectiveTypes": effective_types or ["drug_order"],
+            "temporalApplied": temporal_applied,
+        },
+        request=request,
+    )
 
 
 def _run(client_coro):
@@ -183,6 +210,121 @@ def test_full_chart_continues_when_server_caps_each_page_below_the_requested_lim
     ]
     assert [request["params"]["startIndex"] for request in fake.requests] == [0, 2, 4]
     assert all(request["params"]["limit"] == 500 for request in fake.requests)
+
+
+def test_context_slice_continues_past_server_cap_and_preserves_selection_metadata(
+    monkeypatch,
+):
+    fake = _FakeResponses(
+        [
+            _context_page(
+                [
+                    {
+                        "resourceType": "drug_order",
+                        "resourceUuid": "one",
+                        "tier": "typed",
+                    },
+                    {
+                        "resourceType": "drug_order",
+                        "resourceUuid": "two",
+                        "tier": "typed",
+                    },
+                ],
+                total=3,
+                chart_truncated=True,
+                effective_types=["drug_order", "medication_dispense"],
+            ),
+            _context_page(
+                [
+                    {
+                        "resourceType": "medication_dispense",
+                        "resourceUuid": "three",
+                        "tier": "similarity",
+                    }
+                ],
+                total=3,
+                chart_truncated=True,
+                effective_types=["drug_order", "medication_dispense"],
+            ),
+        ]
+    )
+    monkeypatch.setattr("server.querystore_client.httpx.AsyncClient", fake)
+
+    result = _run(
+        QueryStoreClient("http://openmrs", "service", "secret").fetch_context_slice(
+            "patient-1", "current meds?", interpret=True, limit=500
+        )
+    )
+
+    assert result == ContextSliceFetch(
+        records=[
+            {
+                "resourceType": "drug_order",
+                "resourceUuid": "one",
+                "tier": "typed",
+            },
+            {
+                "resourceType": "drug_order",
+                "resourceUuid": "two",
+                "tier": "typed",
+            },
+            {
+                "resourceType": "medication_dispense",
+                "resourceUuid": "three",
+                "tier": "similarity",
+            },
+        ],
+        slice_id="slice-1",
+        total_count=3,
+        chart_size=365,
+        chart_truncated=True,
+        effective_types=("drug_order", "medication_dispense"),
+        temporal_applied=True,
+    )
+    assert [request["params"]["startIndex"] for request in fake.requests] == [0, 2]
+    assert all(request["params"]["limit"] == 500 for request in fake.requests)
+
+
+def test_context_slice_rejects_mixed_or_duplicate_pages(monkeypatch):
+    first = _context_page(
+        [{"resourceType": "obs", "resourceUuid": "one", "tier": "similarity"}],
+        total=2,
+    )
+    changed = _context_page(
+        [{"resourceType": "obs", "resourceUuid": "two", "tier": "similarity"}],
+        total=2,
+        slice_id="slice-2",
+    )
+    fake = _FakeResponses([first, changed])
+    monkeypatch.setattr("server.querystore_client.httpx.AsyncClient", fake)
+
+    with pytest.raises(InconsistentSnapshotError, match="context slice"):
+        _run(
+            QueryStoreClient("http://openmrs", "service", "secret").fetch_context_slice(
+                "patient-1", "labs?", limit=500
+            )
+        )
+
+    duplicate = _FakeResponses(
+        [
+            _context_page(
+                [{"resourceType": "obs", "resourceUuid": "one", "tier": "similarity"}],
+                total=2,
+            ),
+            _context_page(
+                [{"resourceType": "obs", "resourceUuid": "one", "tier": "similarity"}],
+                total=2,
+            ),
+        ]
+    )
+    monkeypatch.setattr("server.querystore_client.httpx.AsyncClient", duplicate)
+
+    with pytest.raises(ValueError, match="duplicate context-slice"):
+        _run(
+            QueryStoreClient("http://openmrs", "service", "secret").fetch_context_slice(
+                "patient-1", "labs?", limit=500
+            )
+        )
 
 
 def test_full_chart_rejects_duplicate_record_across_pages(monkeypatch):

--- a/tests/test_stage_engine_v2.py
+++ b/tests/test_stage_engine_v2.py
@@ -35,6 +35,26 @@ def test_conversation_history_summary_proves_priors_without_plaintext():
     assert summary != engine._conversation_history_summary(messages[-1:])
 
 
+def test_context_summary_preserves_source_selection_metadata():
+    state = engine._State(messages=[])
+    state.ledger = EvidenceLedger(
+        (),
+        source_metadata={
+            "querystore": {
+                "context_slice": {
+                    "slice_id": "slice-1",
+                    "chart_truncated": True,
+                    "effective_types": ["drug_order"],
+                }
+            }
+        },
+    )
+
+    summary = engine._context_summary(state)
+
+    assert summary["source_metadata"] == state.ledger.source_metadata
+
+
 def test_stage_engine_uses_injected_context_selector():
     record = EvidenceRecord(
         source="alternate",

--- a/tests/test_staged_stream.py
+++ b/tests/test_staged_stream.py
@@ -843,6 +843,74 @@ def test_ground_references_checks_a_multi_citation_claim_against_combined_source
     assert "[2] 2006-06-06 Weight (kg): 71 kg" in prompt
 
 
+def test_ground_references_grounds_each_enumerated_item_against_its_own_source(
+    monkeypatch,
+):
+    # An ENUMERATION sentence — each item cited by its own marker separated by its own item
+    # text — must be grounded per-item against ONLY that item's source, NOT collapsed into one
+    # combined-source verdict. Regression for the compound-citation coupling bug: a small
+    # grounding model asked "does {cotrimoxazole + lamivudine + efavirenz records} support
+    # 'cotrimoxazole, lamivudine, and efavirenz'?" as one unit would fail the whole thing and mark
+    # every citation unsupported. Contrast test_ground_references_checks_a_multi_citation_claim_
+    # against_combined_sources, whose ADJACENT [1][2] markers are one collective claim and stay
+    # combined. Here the markers are SEPARATED by their own item text, so each is its own cluster.
+    fake_chat, calls = _fake_chat_returning_verdicts([["YES", "NO", "YES"]])
+    monkeypatch.setattr(team, "_chat", fake_chat)
+    statement = (
+        "The patient is prescribed cotrimoxazole [2], lamivudine [3], and efavirenz [4]."
+    )
+    refs = [
+        {
+            "index": index,
+            "resourceType": "drug_order",
+            "resourceUuid": f"drug-{index}",
+            "date": "2026-01-26",
+            "usage": [{"location": "answer", "text": statement}],
+        }
+        for index in (2, 3, 4)
+    ]
+    mappings = [
+        {"index": 2, "date": "2026-01-26", "text": "Drug order: cotrimoxazole"},
+        {"index": 3, "date": "2026-01-26", "text": "Drug order: lamivudine"},
+        {"index": 4, "date": "2026-01-26", "text": "Drug order: efavirenz"},
+    ]
+
+    async def _run():
+        return await team._ground_references(None, "M", statement, refs, mappings)
+
+    grounded = asyncio.run(_run())
+    # Each citation gets its OWN independent verdict, not one shared across the group.
+    assert [item["groundingStatus"] for item in grounded] == [
+        "verified",
+        "unsupported",
+        "verified",
+    ]
+    assert [item["grounded"] for item in grounded] == [True, False, True]
+    # Each is scoped to its own single record, not a source_set.
+    assert [item["groundingScope"] for item in grounded] == [
+        "record",
+        "record",
+        "record",
+    ]
+    assert all("groundingGroup" not in item for item in grounded)
+    # Each grounding check cites only that item's own source index and its own item clause.
+    assert [check_source_indices(item) for item in grounded] == [[2], [3], [4]]
+    claims = [item["groundingChecks"][0]["claim"] for item in grounded]
+    assert "cotrimoxazole" in claims[0] and "lamivudine" not in claims[0]
+    assert "lamivudine" in claims[1] and "efavirenz" not in claims[1]
+    assert "efavirenz" in claims[2]
+    # One batched call carrying one PAIR per enumerated item (hub's single-slot batching model),
+    # but three independent verdicts positionally mapped — the fix is per-item claims+sources,
+    # not per-item network calls.
+    assert len(calls) == 1
+    prompt = calls[0]["messages"][0]["content"]
+    assert prompt.count("PAIR ") == 3
+
+
+def check_source_indices(grounded_ref):
+    return grounded_ref["groundingChecks"][0]["source_indices"]
+
+
 @pytest.mark.parametrize(
     "statement",
     (
@@ -2684,10 +2752,16 @@ def test_knowledge_reference_survives_source_set_grounding_with_provenance(monke
         answer_usage_location="indepth",
     )
 
+    # The patient-fact citation [1] and the knowledge-base provenance citation [2] back DIFFERENT
+    # clauses of this sentence (separated by their own text), so each is grounded per-claim against
+    # only its own source rather than as one combined source_set — the same compound-citation
+    # decoupling as the enumeration case. The point of this test is that the knowledge reference's
+    # provenance/source metadata SURVIVES grounding, which it still does.
     async def supported(_client, _model, pairs):
-        assert len(pairs) == 1
-        assert "[1]" in pairs[0][0] and "[2]" in pairs[0][0]
-        return [True]
+        assert len(pairs) == 2
+        assert "[1]" in pairs[0][0] and "Examplemed" in pairs[0][1]
+        assert "[2]" in pairs[1][0] and "monitoring" in pairs[1][1]
+        return [True, True]
 
     monkeypatch.setattr(team, "_entailment_verdicts", supported)
     grounded = asyncio.run(
@@ -2705,7 +2779,9 @@ def test_knowledge_reference_survives_source_set_grounding_with_provenance(monke
         "url": "https://example.test/guide",
         "license": "CC BY",
     }
-    assert kb_reference["groundingGroup"] == [1, 2]
+    # Now grounded as its own clause against its own source, so it is record-scoped, not a set.
+    assert kb_reference["groundingScope"] == "record"
+    assert "groundingGroup" not in kb_reference
 
 
 def test_product_review_and_final_event_preserve_grounded_knowledge_reference(monkeypatch):


### PR DESCRIPTION
## Summary

This follow-up applies only three post-#13 fixes on top of current main:

- read all server-capped QueryStore context-slice pages
- ground enumerated citations individually
- validate complete context slices and preserve their selection metadata

The resulting source tree is byte-identical to the previously source-tested safe hub revision 2eb9815. It intentionally excludes the unsafe review fast-path that could classify clinically meaningful unit or route edits as harmless.

## Validation

- 627 hub tests passed
- clean branch is exactly three commits ahead of current main
- comparison with 2eb9815 is empty
- unsafe review fast-path helper is absent

## Companion integration

After merge, the validation harness will pin the resulting main commit and rebuild its own post-merge follow-up from current harness main.