### PR TITLE
fix: restore the Catalyst query profile matrix on llama-server aliases

### DIFF
--- a/server/levels.yaml
+++ b/server/levels.yaml
@@ -19,8 +19,8 @@ profiles:
     topology: caller
     stages: [context, query_generate, query_lint, query_review, query_finalize]
     models:
-      query_generate: google/gemma-4-e4b
-      query_review: qwen2.5-14b-instruct-mlx
+      query_generate: gemma-e4b
+      query_review: qwen2.5-14b
     prompts:
       query_generate: catalyst-query-generate
       query_review: catalyst-query-review
@@ -59,6 +59,88 @@ profiles:
         query_generate: gemma-4-12b
     visibility: product
     selection_priority: 20
+    outputContracts: [catalyst.query.v1]
+
+  # Cross-family reviewed lane: the reviewer is a different model family from the
+  # writer, so review is genuinely independent rather than a model re-reading its
+  # own output. Both stay resident on a 24G-class GPU once warm.
+  catalyst-query-gemma-4-12b-qwen2.5-14b-checked:
+    workflow: catalyst_query
+    label: "Catalyst query — Gemma 4 12B writer, Qwen 2.5 14B reviewer"
+    topology: caller
+    stages: [context, query_generate, query_lint, query_review, query_finalize]
+    models:
+      query_generate: gemma-4-12b
+      query_review: qwen2.5-14b
+    prompts:
+      query_generate: catalyst-query-generate
+      query_review: catalyst-query-review
+    knobs:
+      query_generate: {temperature: 0, dry: 0, maxTokens: 1024}
+      query_review: {temperature: 0, dry: 0, maxTokens: 1024}
+    policies:
+      orchestration_owner: catalyst
+      generation_attempts: 3
+      allowed_operation: select
+      collaborative_review: true
+      model_classes:
+        query_generate: gemma-4
+        query_review: qwen2.5
+    visibility: product
+    selection_priority: 15
+    outputContracts: [catalyst.query.v1]
+
+  # Self-checked single-model lane: one Q4 writer fills both roles, so a second
+  # pass is available on a CPU-only host without loading a second large model.
+  # Not collaborative — same model class reviewing itself.
+  catalyst-query-gemma-4-12b-q4-checked:
+    workflow: catalyst_query
+    label: "Catalyst query — Gemma 4 12B (Q4, self-checked)"
+    topology: caller
+    stages: [context, query_generate, query_lint, query_review, query_finalize]
+    models:
+      query_generate: gemma-4-12b-q4
+      query_review: gemma-4-12b-q4
+    prompts:
+      query_generate: catalyst-query-generate
+      query_review: catalyst-query-review
+    knobs:
+      query_generate: {temperature: 0, dry: 0, maxTokens: 1024}
+      query_review: {temperature: 0, dry: 0, maxTokens: 1024}
+    policies:
+      orchestration_owner: catalyst
+      generation_attempts: 3
+      allowed_operation: select
+      collaborative_review: false
+      model_classes:
+        query_generate: gemma-4-q4
+        query_review: gemma-4-q4
+    visibility: product
+    selection_priority: 30
+    outputContracts: [catalyst.query.v1]
+
+  # Smallest writer-only lane: runs on any host. Deterministic lint decides
+  # whether the single candidate can be finalized; there is no reviewer role.
+  catalyst-query-qwen-coder-1.5b:
+    workflow: catalyst_query
+    label: "Catalyst query — Qwen 2.5 Coder 1.5B (Q4, writer only)"
+    topology: caller
+    stages: [context, query_generate, query_lint, query_finalize]
+    models:
+      query_generate: qwen2.5-coder-1.5b-instruct-q4_k_m
+    prompts:
+      query_generate: catalyst-query-generate
+    knobs:
+      query_generate: {temperature: 0, dry: 0, maxTokens: 1024}
+    policies:
+      orchestration_owner: catalyst
+      generation_attempts: 3
+      allowed_operation: select
+      collaborative_review: false
+      model_classes:
+        query_generate: qwen2.5-coder
+    visibility: product
+    selection_priority: 40
     outputContracts: [catalyst.query.v1]
 
   single-e4b-checked:

--- a/tests/test_generic_role.py
+++ b/tests/test_generic_role.py
@@ -121,8 +121,8 @@ def test_catalyst_query_profile_owns_model_prompt_and_knobs(monkeypatch):
         generic_role,
         "_served_backend_model_metadata",
         lambda: {
-            "google/gemma-4-e4b": {},
-            "qwen2.5-14b-instruct-mlx": {},
+            "gemma-e4b": {},
+            "qwen2.5-14b": {},
         },
     )
 
@@ -140,9 +140,9 @@ def test_catalyst_query_profile_owns_model_prompt_and_knobs(monkeypatch):
         )
 
     assert response.status_code == 200
-    assert response.json()["model"] == "google/gemma-4-e4b"
+    assert response.json()["model"] == "gemma-e4b"
     assert response.json()["profile_id"] == "catalyst-query-e4b-qwen14b"
-    assert captured["model"] == "google/gemma-4-e4b"
+    assert captured["model"] == "gemma-e4b"
     assert captured["messages"][0]["role"] == "system"
     assert "Catalyst governed analytics-query" in captured["messages"][0]["content"]
     assert captured["kwargs"]["temperature"] == 0.0
@@ -154,8 +154,8 @@ def test_catalyst_query_profile_rejects_caller_model_and_knob_overrides(monkeypa
         generic_role,
         "_served_backend_model_metadata",
         lambda: {
-            "google/gemma-4-e4b": {},
-            "qwen2.5-14b-instruct-mlx": {},
+            "gemma-e4b": {},
+            "qwen2.5-14b": {},
         },
     )
     response = TestClient(app).post(
@@ -174,7 +174,7 @@ def test_catalyst_query_profile_reports_missing_model_without_generating(monkeyp
     monkeypatch.setattr(
         generic_role,
         "_served_backend_model_metadata",
-        lambda: {"google/gemma-4-e4b": {}},
+        lambda: {"gemma-e4b": {}},
     )
     response = TestClient(app).post(
         "/v1/hub/query-profiles/catalyst-query-e4b-qwen14b/roles/query_review/generate",
@@ -185,7 +185,7 @@ def test_catalyst_query_profile_reports_missing_model_without_generating(monkeyp
     assert response.json()["detail"] == {
         "code": "profile_unavailable",
         "profileId": "catalyst-query-e4b-qwen14b",
-        "unavailableReasons": ["model_not_advertised:qwen2.5-14b-instruct-mlx"],
+        "unavailableReasons": ["model_not_advertised:qwen2.5-14b"],
     }
 
 
@@ -194,8 +194,8 @@ def test_catalyst_query_profile_rejects_caller_system_prompt(monkeypatch):
         generic_role,
         "_served_backend_model_metadata",
         lambda: {
-            "google/gemma-4-e4b": {},
-            "qwen2.5-14b-instruct-mlx": {},
+            "gemma-e4b": {},
+            "qwen2.5-14b": {},
         },
     )
     response = TestClient(app).post(

--- a/tests/test_profiles_v2.py
+++ b/tests/test_profiles_v2.py
@@ -359,6 +359,9 @@ def test_catalyst_uses_the_same_profile_schema_with_caller_owned_orchestration()
     assert catalyst_query_profile_ids() == [
         "catalyst-query-e4b-qwen14b",
         "catalyst-query-gemma-4-12b",
+        "catalyst-query-gemma-4-12b-qwen2.5-14b-checked",
+        "catalyst-query-gemma-4-12b-q4-checked",
+        "catalyst-query-qwen-coder-1.5b",
     ]
     profile = get_catalyst_query_profile("catalyst-query-e4b-qwen14b")
 
@@ -367,8 +370,8 @@ def test_catalyst_uses_the_same_profile_schema_with_caller_owned_orchestration()
     assert profile.topology == "caller"
     assert profile.policies["orchestration_owner"] == "catalyst"
     assert profile.models == {
-        "query_generate": "google/gemma-4-e4b",
-        "query_review": "qwen2.5-14b-instruct-mlx",
+        "query_generate": "gemma-e4b",
+        "query_review": "qwen2.5-14b",
     }
     assert profile.stages == (
         "context",
@@ -387,7 +390,25 @@ def test_catalyst_uses_the_same_profile_schema_with_caller_owned_orchestration()
         "query_finalize",
     )
     assert writer_only.policies["collaborative_review"] is False
-    assert validate_catalyst_query_profiles() == (profile, writer_only)
+    validated = validate_catalyst_query_profiles()
+    assert len(validated) == len(catalyst_query_profile_ids())
+    assert validated[:2] == (profile, writer_only)
+
+
+def test_catalyst_query_models_are_llama_server_aliases():
+    """Every Catalyst role model must name a llama-server (GGUF) alias.
+
+    The MVP stack routes Hub through the llama.cpp router, so a provider-prefixed
+    or MLX-suffixed id (an LM Studio alias) is never advertised by the backend and
+    silently strands the profile as `model_not_advertised`.
+    """
+    for profile_id in catalyst_query_profile_ids():
+        profile = get_catalyst_query_profile(profile_id)
+        for role, model in profile.models.items():
+            assert "/" not in model, f"{profile_id}.{role} is provider-prefixed: {model}"
+            assert not model.endswith("-mlx"), (
+                f"{profile_id}.{role} is an MLX alias: {model}"
+            )
 
     # Clinical execution/discovery cannot accidentally run a caller-owned SQL
     # profile through the ChartSearchAI stage engine.

--- a/tests/test_profiles_v2.py
+++ b/tests/test_profiles_v2.py
@@ -410,11 +410,11 @@ def test_catalyst_query_models_are_llama_server_aliases():
                 f"{profile_id}.{role} is an MLX alias: {model}"
             )
 
-    # Clinical execution/discovery cannot accidentally run a caller-owned SQL
-    # profile through the ChartSearchAI stage engine.
-    assert profile.id not in profile_ids()
-    with pytest.raises(ModelNotFoundError):
-        get_profile(profile.id)
+        # Clinical execution/discovery cannot accidentally run a caller-owned SQL
+        # profile through the ChartSearchAI stage engine.
+        assert profile.id not in profile_ids()
+        with pytest.raises(ModelNotFoundError):
+            get_profile(profile.id)
 
 
 def test_catalyst_prompt_evidence_uses_workbench_sha256_contract():


### PR DESCRIPTION
Companion to DIGI-UW/openelis-catalyst#9. Merge this first — Catalyst's health gate checks these aliases.

## What went wrong

The 2026-08-05 `refactor(mvp): use Hub-owned query profiles` (openelis-catalyst `55e7192`) moved profile ownership from the Gateway to Hub. Moving ownership here was the right call — `levels_loader.py:203-208` discovers **any** `workflow: catalyst_query` profile from `levels.yaml`, so profiles are genuinely config-only. But the move landed lossily:

1. **Five profiles became one.** The deleted `catalyst-gateway/src/catalyst/query_profiles.py` registry had writer-only (the default), self-checked, small bundled, full-weight, and cross-family reviewed lanes. Only a single reviewed profile was written here.
2. **Model ids were rewritten from llama.cpp router (GGUF) aliases to LM Studio/MLX aliases.** Every deleted profile used `gemma-4-12b-q4`, `gemma-4-12b`, `qwen2.5-14b`, `qwen2.5-coder-1.5b-instruct-q4_k_m` — exact `scripts/llama-router.ini` section names. The replacement used `google/gemma-4-e4b` and `qwen2.5-14b-instruct-mlx`.

The MVP stack routes Hub at the llama.cpp router, which never advertises the MLX ids, so `catalyst-query-e4b-qwen14b` reported `model_not_advertised` against the supported backend and could only resolve against LM Studio on :1234.

## Changes

- `catalyst-query-e4b-qwen14b` → `gemma-e4b` / `qwen2.5-14b` (router aliases it can actually reach)
- Restored as configuration, no code changes needed:
  - `catalyst-query-gemma-4-12b-qwen2.5-14b-checked` — cross-family reviewed (genuinely independent review)
  - `catalyst-query-gemma-4-12b-q4-checked` — self-checked single model (review on a CPU-only host)
  - `catalyst-query-qwen-coder-1.5b` — smallest writer-only lane
- New `test_catalyst_query_models_are_llama_server_aliases` rejects provider-prefixed and `-mlx` ids, so this exact regression can't recur silently.

`policies.model_classes` is deliberately untouched: it only labels evidence output (`levels_loader.py:230-241`, `783-785`) and is never consulted for availability — it is not a resolver and I did not turn it into one.

## Validation

691 tests pass (was 689 + the 2 added/updated).